### PR TITLE
SocketManager: do not block if tasks are runnable

### DIFF
--- a/Modules/Indigo/SocketManager/module/src/socketmanager.c
+++ b/Modules/Indigo/SocketManager/module/src/socketmanager.c
@@ -756,7 +756,12 @@ ind_soc_select_and_run(int run_for_ms)
     current = start = INDIGO_CURRENT_TIME;
 
     do {
-        next_timer_ms = find_next_timer_expiration(current);
+        if (list_empty(&tasks)) {
+            next_timer_ms = find_next_timer_expiration(current);
+        } else {
+            /* Do not sleep if a task is ready */
+            next_timer_ms = 0;
+        }
 
         timeout_ms = calculate_next_timeout(start, current,
                                             run_for_ms, next_timer_ms);

--- a/Modules/Indigo/SocketManager/utest/main.c
+++ b/Modules/Indigo/SocketManager/utest/main.c
@@ -496,6 +496,12 @@ test_task(void)
     memset(counters, 0, sizeof(counters));
     ind_soc_select_and_run(0);
     INDIGO_ASSERT(counters[0] == 1);
+
+    /* Task should be repeatedly rescheduled in the same call to ind_soc_select_and_run */
+    INDIGO_ASSERT(ind_soc_task_register(task_callback_yield, &counters[0], 0) == INDIGO_ERROR_NONE);
+    memset(counters, 0, sizeof(counters));
+    ind_soc_select_and_run(500);
+    INDIGO_ASSERT(counters[0] == 100);
 }
 
 static void


### PR DESCRIPTION
Reviewer: @carlroth

I saw flow deletion, which I recently converted to a task, taking far too long
(50 - 100 ms). It turned out that if a task yielded it would not be scheduled
until the next event (timer or socket), at which point we would check the task
list again. The simple fix is to not go to sleep if there are tasks we can run.

Added a new unit test that would have caught this.
