### PR TITLE
Add port_desc_stats processing support

### DIFF
--- a/Modules/Indigo/OFStateManager/module/src/handlers.h
+++ b/Modules/Indigo/OFStateManager/module/src/handlers.h
@@ -92,6 +92,9 @@ extern indigo_error_t ind_core_desc_stats_request_handler(
 extern indigo_error_t ind_core_table_stats_request_handler(
     of_object_t *_obj,
     indigo_cxn_id_t cxn);
+extern indigo_error_t ind_core_port_desc_stats_request_handler(
+    of_object_t *_obj,
+    indigo_cxn_id_t cxn_id);
 extern indigo_error_t ind_core_features_request_handler(
     of_object_t *_obj,
     indigo_cxn_id_t cxn);

--- a/Modules/Indigo/OFStateManager/module/src/ofstatemanager.c
+++ b/Modules/Indigo/OFStateManager/module/src/ofstatemanager.c
@@ -254,6 +254,10 @@ indigo_core_receive_controller_message(indigo_cxn_id_t cxn, of_object_t *obj)
         rv = ind_core_desc_stats_request_handler(obj, cxn);
         break;
 
+    case OF_PORT_DESC_STATS_REQUEST:
+        rv = ind_core_port_desc_stats_request_handler(obj, cxn);
+        break;
+
     case OF_FEATURES_REQUEST:
         rv = ind_core_features_request_handler(obj, cxn);
         break;

--- a/Modules/Indigo/indigo/module/inc/indigo/port_manager.h
+++ b/Modules/Indigo/indigo/module/inc/indigo/port_manager.h
@@ -64,6 +64,19 @@ extern indigo_error_t indigo_port_features_get(
     of_features_reply_t *features);
 
 
+/**
+ * @brief Handle a port_desc_stats get request
+ * @param port_desc_stats_reply The port_desc_stats_reply reply message 
+ * to be filled out
+ *
+ * This is a synchronous call.
+ *
+ * Ownership of the port_desc_stats_reply object is maintained by the caller
+ */
+extern indigo_error_t indigo_port_desc_stats_get(
+    of_port_desc_stats_reply_t *port_desc_stats_reply);
+
+
 /****************************************************************
  * Configuration interface routines provided by port manager
  ****************************************************************/


### PR DESCRIPTION
Add support port_desc_stats_request in indigo, which is typically Openflow 1.3 OFPT_MULTIPART_REQUEST
with MFPMP_PORT_DESC.
