### PR TITLE
SocketManager: fix timeslice exceeded log message

### DIFF
--- a/Modules/Indigo/SocketManager/module/src/socketmanager.c
+++ b/Modules/Indigo/SocketManager/module/src/socketmanager.c
@@ -627,7 +627,7 @@ after_callback(void)
         INDIGO_TIME_DIFF_ms(callback_start_time, INDIGO_CURRENT_TIME);
     if (elapsed >= SOCKETMANAGER_CONFIG_TIMESLICE_MS * 2) {
         LOG_VERBOSE("Callback exceeded 2x timeslice (ran for %d ms, timeslice is %d ms)",
-                    elapsed, SOCKETMANAGER_CONFIG_TIMESLICE_MS);
+                    (int)elapsed, SOCKETMANAGER_CONFIG_TIMESLICE_MS);
     }
 }
 


### PR DESCRIPTION
Reviewer: trivial

We were passing a 64-bit int to printf where it expected a 32-bit int, so on 
some architectures the varargs were interpreted incorrectly.

This would have been caught by the GCC `format` attribute. I attempted to add
this attribute to aim_log_common but it raised errors for format strings using
the AIM datatype syntax.
