### PR TITLE
murmur: fix strict aliasing issue

### DIFF
--- a/Modules/murmur/module/inc/murmur/murmur.h
+++ b/Modules/murmur/module/inc/murmur/murmur.h
@@ -55,7 +55,14 @@ murmur_hash(const void *key, int len, uint32_t seed)
     const uint32_t c1 = 0xcc9e2d51;
     const uint32_t c2 = 0x1b873593;
 
-    const uint32_t *blocks = (const uint32_t *)(data + nblocks*4);
+    /* Workaround for strict aliasing */
+#ifdef __GNUC__
+    typedef uint32_t __attribute__((__may_alias__)) uint32_aliased_t;
+#else
+    typedef uint32_t uint32_aliased_t;
+#endif
+
+    const uint32_aliased_t *blocks = (const uint32_aliased_t *)(data + nblocks*4);
 
     const uint8_t* tail;
     uint32_t k1;


### PR DESCRIPTION
Reviewer: @jnealtowns

If anyone else has dealt with this stuff before please feel free to review too.

C99 makes it illegal for different pointer types (with exceptions like char *)
to refer to the same memory. GCC interprets this very strictly, which caused
murmur_hash to return an incorrect result when inlined because it referenced
a struct using a uint32_t pointer.

Relevant section of the GCC manual: http://gcc.gnu.org/onlinedocs/gcc/Type-Attributes.html
