### PR TITLE
remove ind_core_ft_iter

### DIFF
--- a/Modules/Indigo/OFStateManager/module/inc/OFStateManager/ofstatemanager.h
+++ b/Modules/Indigo/OFStateManager/module/inc/OFStateManager/ofstatemanager.h
@@ -96,17 +96,6 @@ indigo_error_t ind_core_serial_num_set(of_serial_num_t serial_num);
 indigo_error_t ind_core_serial_num_get(of_serial_num_t serial_num);
 
 /**
- * Flow Table Iterator
- */
-typedef int (ind_core_ft_iter_f)(indigo_flow_id_t id,
-                                 of_flow_add_t* ofa, void* cookie);
-
-/**
- * Iterate over all core flowtable entries.
- */
-indigo_error_t ind_core_ft_iter(ind_core_ft_iter_f iter, void* cookie);
-
-/**
  * Dump all entries in the flow table.
  * This is verbose.
  */

--- a/Modules/Indigo/OFStateManager/module/src/ofstatemanager.c
+++ b/Modules/Indigo/OFStateManager/module/src/ofstatemanager.c
@@ -1100,30 +1100,6 @@ flow_expiration_timer(void *cookie)
                                         INDIGO_POINTER_TO_COOKIE(state));
 }
 
-indigo_error_t
-ind_core_ft_iter(ind_core_ft_iter_f iterf, void* cookie)
-{
-    ft_instance_t ft = ind_core_ft;
-    ft_entry_t *entry;
-    list_links_t *cur, *next;
-
-    if(iterf == NULL) {
-        return INDIGO_ERROR_PARAM;
-    }
-    if(ft == NULL) {
-        return INDIGO_ERROR_NONE;
-    }
-    FT_ITER(ft, entry, cur, next) {
-        if (!FT_FLOW_STATE_IS_DELETED(entry->state)) {
-            if (iterf(entry->id, entry->flow_add, cookie) < 0) {
-                break;
-            }
-        }
-    }
-
-    return INDIGO_ERROR_NONE;
-}
-
 void
 ind_core_ft_dump(aim_pvs_t* pvs)
 {


### PR DESCRIPTION
Reviewer: @jnealtowns

I rewrote the only users (ind_core_ft_dump and ind_core_ft_show).

This is part of my flowtable memory optimization effort. I intend to remove the
flow_add from the flowtable entry to save space.
