### PR TITLE
Initialize connection manager earlier

### DIFF
--- a/Modules/Indigo/Configuration/module/make.mk
+++ b/Modules/Indigo/Configuration/module/make.mk
@@ -27,4 +27,4 @@
 THISDIR := $(dir $(lastword $(MAKEFILE_LIST)))
 Configuration_INCLUDES := -I $(THISDIR)inc
 Configuration_INTERNAL_INCLUDES := -I $(THISDIR)src
-Configuration_DEPENDMODULE_ENTRIES := ucli:configuration
+Configuration_DEPENDMODULE_ENTRIES := ucli:configuration init:configuration

--- a/Modules/Indigo/OFConnectionManager/module/src/ofconnectionmanager.c
+++ b/Modules/Indigo/OFConnectionManager/module/src/ofconnectionmanager.c
@@ -962,6 +962,8 @@ ind_cxn_init(ind_cxn_config_t *config)
     /* Verify required functions are non-NULL */
     INDIGO_MEM_COPY(&cxn_config, config, sizeof(*config));
 
+    module_init();
+
     init_done = 1;
 
     return INDIGO_ERROR_NONE;
@@ -980,7 +982,6 @@ ind_cxn_enable_set(int enable)
     }
 
     if (enable && !module_enabled) {
-        module_init();
         LOG_INFO("Enabling OF connection mgr");
         module_enabled = 1;
     } else if (!enable && module_enabled) {


### PR DESCRIPTION
Reviewer: @dtalayco @rlane

Call module_init earlier from ind_cxn_init, instead of ind_cxn_enable_set.

Also build with init:configuration, so that the configuration module
registers with the logging module.
