### PR TITLE
cxnmgr error handling

### DIFF
--- a/Modules/Indigo/OFConnectionManager/module/src/ofconnectionmanager.c
+++ b/Modules/Indigo/OFConnectionManager/module/src/ofconnectionmanager.c
@@ -242,11 +242,13 @@ indigo_cxn_socket_ready_callback(
         int socket_error = 0;
         socklen_t len = sizeof(socket_error);
         getsockopt(cxn->sd, SOL_SOCKET, SO_ERROR, &socket_error, &len);
-        LOG_ERROR("Error seen on connection %s: %s",
-                  cxn_ip_string(cxn), strerror(socket_error));
-        ind_cxn_disconnect(cxn);
-        ++ind_cxn_internal_errors;
-        return;
+        if (socket_error != 0) {
+            LOG_ERROR("Error seen on connection %s: %s",
+                      cxn_ip_string(cxn), strerror(socket_error));
+            ind_cxn_disconnect(cxn);
+            ++ind_cxn_internal_errors;
+            return;
+        }
     }
 
     if (read_ready) {


### PR DESCRIPTION
Reviewer: @rlane

On error notification, check socket error value first before disconnecting.

After interrupting the flow stats output from the 'show flowtable' cli, connections to 127.0.0.1:6634 are dropped after the handshake completes:
Aug 20 17:14:32 lb9-4-fixme ofad[28657]: ofconnectionmanager: TRACE: Soc 18 ready, cxn 0x102fffd0. rd 1. wr 0. er 1
Aug 20 17:14:32 lb9-4-fixme ofad[28657]: ofconnectionmanager: TRACE: cxn 127.0.0.1:6634: Error reading from socket: Resource temporarily unavailable
Aug 20 17:14:32 lb9-4-fixme ofad[28657]: ofconnectionmanager: TRACE: cxn 127.0.0.1:6634: Still need 8 bytes for msg hdr
Aug 20 17:14:32 lb9-4-fixme ofad[28657]: ofconnectionmanager: ERROR: Error seen on connection 127.0.0.1:6634: Success
Aug 20 17:14:32 lb9-4-fixme ofad[28657]: ofconnectionmanager: VERBOSE: cxn 127.0.0.1:6634: Forcing disconnection

It's not clear to me how to clear the POLLERR indication from poll(); any enlightenment would be appreciated.  Thanks.
