### PR TITLE
Add statistics to provide visibility into StateManager operation.

### DIFF
--- a/modules/OFStateManager/module/src/ofstatemanager.c
+++ b/modules/OFStateManager/module/src/ofstatemanager.c
@@ -64,9 +64,9 @@ int ind_core_module_enabled = 0;
 /**
  * @brief Statistics for debugging
  */
-static uint32_t core_flow_mods = 0;
-static uint32_t core_packet_ins = 0;
-static uint32_t core_packet_outs = 0;
+static uint32_t ind_core_flow_mods = 0;
+static uint32_t ind_core_packet_ins = 0;
+static uint32_t ind_core_packet_outs = 0;
 
 
 /**
@@ -105,7 +105,7 @@ indigo_core_packet_in(of_packet_in_t *packet_in)
     }
 
     LOG_TRACE("Packet in rcvd");
-    core_packet_ins++;
+    ind_core_packet_ins++;
 
     rv = indigo_cxn_send_controller_message(INDIGO_CXN_ID_UNSPECIFIED,
                                             packet_in);
@@ -225,32 +225,32 @@ indigo_core_receive_controller_message(indigo_cxn_id_t cxn, of_object_t *obj)
         break;
 
     case OF_PACKET_OUT:
-        core_packet_outs++;
+        ind_core_packet_outs++;
         rv = ind_core_packet_out_handler(obj, cxn);
         break;
 
     case OF_FLOW_ADD:
-        core_flow_mods++;
+        ind_core_flow_mods++;
         rv = ind_core_flow_add_handler(obj, cxn);
         break;
 
     case OF_FLOW_MODIFY:
-        core_flow_mods++;
+        ind_core_flow_mods++;
         rv = ind_core_flow_modify_handler(obj, cxn);
         break;
 
     case OF_FLOW_MODIFY_STRICT:
-        core_flow_mods++;
+        ind_core_flow_mods++;
         rv = ind_core_flow_modify_strict_handler(obj, cxn);
         break;
 
     case OF_FLOW_DELETE:
-        core_flow_mods++;
+        ind_core_flow_mods++;
         rv = ind_core_flow_delete_handler(obj, cxn);
         break;
 
     case OF_FLOW_DELETE_STRICT:
-        core_flow_mods++;
+        ind_core_flow_mods++;
         rv = ind_core_flow_delete_strict_handler(obj, cxn);
         break;
 
@@ -1273,17 +1273,17 @@ ind_core_ft_stats(aim_pvs_t *pvs)
  */
 
 void
-ind_core_stats_get(uint32_t *total_flows,
-                   uint32_t *flow_mods,
-                   uint32_t *packet_ins,
-                   uint32_t *packet_outs)
+indigo_core_stats_get(uint32_t *total_flows,
+                      uint32_t *flow_mods,
+                      uint32_t *packet_ins,
+                      uint32_t *packet_outs)
 {
     *total_flows = ind_core_ft->status.current_count;
-    *flow_mods = core_flow_mods;
-    *packet_ins = core_packet_ins;
-    *packet_outs = core_packet_outs;
+    *flow_mods = ind_core_flow_mods;
+    *packet_ins = ind_core_packet_ins;
+    *packet_outs = ind_core_packet_outs;
 
-    core_flow_mods = 0;
-    core_packet_ins = 0;
-    core_packet_outs = 0;
+    ind_core_flow_mods = 0;
+    ind_core_packet_ins = 0;
+    ind_core_packet_outs = 0;
 }

--- a/modules/indigo/module/inc/indigo/of_state_manager.h
+++ b/modules/indigo/module/inc/indigo/of_state_manager.h
@@ -347,10 +347,10 @@ extern void indigo_core_connection_count_notify(
  */
 
 extern void
-ind_core_stats_get(uint32_t *total_flows,
-                   uint32_t *flow_mods,
-                   uint32_t *packet_ins,
-                   uint32_t *packet_outs);
+indigo_core_stats_get(uint32_t *total_flows,
+                      uint32_t *flow_mods,
+                      uint32_t *packet_ins,
+                      uint32_t *packet_outs);
 
 #endif /* _INDIGO_OF_STATE_MANAGER_H_ */
 /** @} */


### PR DESCRIPTION
Reviewer: @rlane

This is just the API that IVS could call periodically to gather statistics from core.
