### PR TITLE
submodules/init.py: use /usr/bin/env instead of hardcoding python path

### DIFF
--- a/submodules/init.py
+++ b/submodules/init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python 
+#!/usr/bin/env python
 ################################################################
 #
 #        Copyright 2013, Big Switch Networks, Inc. 


### PR DESCRIPTION
Reviewer: trivial
