### PR TITLE
OFConnectionManager: OF 1.3 role request implementation

### DIFF
--- a/modules/OFConnectionManager/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager.c
@@ -77,6 +77,8 @@ int successful_handshakes; /* Number of times handshake completes */
 
 uint32_t ind_cxn_internal_errors;
 
+uint64_t ind_cxn_generation_id;
+
 /****************************************************************
  * Connection Manager Private Data
  ****************************************************************/
@@ -397,6 +399,11 @@ module_init(void)
     }
 
     ind_cfg_register(&ind_cxn_cfg_ops);
+
+    /* Pseudo-random generation ID to force controller to ask for it */
+    ind_cxn_generation_id = INDIGO_CURRENT_TIME * 0x9e3779b97f4a7c13llu;
+
+    LOG_VERBOSE("Initial generation id: 0x%016"PRIx64, ind_cxn_generation_id);
 
     return INDIGO_ERROR_NONE;
 }

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
@@ -62,6 +62,11 @@ extern int have_local_connection;
  */
 extern int remote_connection_count;
 
+/**
+ * Role request generation ID
+ */
+extern uint64_t ind_cxn_generation_id;
+
 
 /* conversion functions from cookie with generation id to connection and vice versa */
 void *cxn_to_cookie(connection_t *cxn);


### PR DESCRIPTION
Reviewer: @ducwindow

Largely the same as the nicira_role code, but just different enough that the 
only common pieces are `ind_cxn_change_master` and `role_to_string`.

The full generation ID semantics are supported. The initial generation ID is 
randomized to force controllers to request it.
