### PR TITLE
L2 idle notification: once per idle_timeout period

### DIFF
--- a/modules/OFStateManager/module/src/ofstatemanager.c
+++ b/modules/OFStateManager/module/src/ofstatemanager.c
@@ -963,6 +963,7 @@ flow_expiration_timer(void *cookie)
                           INDIGO_FLOW_ID_PRINTF_ARG(entry->id));
                 if (entry->flags & OF_FLOW_MOD_FLAG_BSN_SEND_IDLE) {
                     send_idle_notification(entry);
+                    entry->last_counter_change = current_time;
                 } else {
                     ind_core_flow_entry_delete(entry, 
                                                INDIGO_FLOW_REMOVED_IDLE_TIMEOUT);


### PR DESCRIPTION
Reviewer: @rlane

Reset last_counter_change to change idle notification frequency to once per idle_timeout period.
