### PR TITLE
OFStateManager: promote listeners to Indigo architecture headers

### DIFF
--- a/modules/OFStateManager/module/inc/OFStateManager/ofstatemanager.h
+++ b/modules/OFStateManager/module/inc/OFStateManager/ofstatemanager.h
@@ -112,43 +112,5 @@ void ind_core_ft_show(aim_pvs_t* pvs);
  */
 void ind_core_ft_stats(aim_pvs_t* pvs);
 
-/**
- * Listener interfaces
- *
- * These functions allow modules not defined in the Indigo architecture to
- * react to dataplane events and controller messages. This is useful for
- * implementing add-on switch functionality like LACP and LLDP offloads.
- */
-
-/**
- * If any listener returns DROP, the event will not be handled by
- * OFStateManager. All listeners will still see the event.
- */
-typedef enum ind_core_listener_result {
-    IND_CORE_LISTENER_RESULT_PASS = 0,
-    IND_CORE_LISTENER_RESULT_DROP = 1,
-} ind_core_listener_result_t;
-
-/**
- * Packet-in listener registration
- */
-typedef ind_core_listener_result_t (*ind_core_packet_in_listener_f)(of_packet_in_t *packet_in);
-indigo_error_t ind_core_packet_in_listener_register(ind_core_packet_in_listener_f fn);
-void ind_core_packet_in_listener_unregister(ind_core_packet_in_listener_f fn);
-
-/**
- * Port status listener registration
- */
-typedef ind_core_listener_result_t (*ind_core_port_status_listener_f)(of_port_status_t *port_status);
-indigo_error_t ind_core_port_status_listener_register(ind_core_port_status_listener_f fn);
-void ind_core_port_status_listener_unregister(ind_core_port_status_listener_f fn);
-
-/**
- * Message listener registration
- */
-typedef ind_core_listener_result_t (*ind_core_message_listener_f)(indigo_cxn_id_t cxn_id, of_object_t *msg);
-indigo_error_t ind_core_message_listener_register(ind_core_message_listener_f fn);
-void ind_core_message_listener_unregister(ind_core_message_listener_f fn);
-
 #endif /* __OFSTATEMANAGER_H__ */
 /** @} */

--- a/modules/OFStateManager/module/src/listener.c
+++ b/modules/OFStateManager/module/src/listener.c
@@ -37,7 +37,7 @@ static biglist_t *message_listeners;
 /* Packet in */
 
 indigo_error_t
-ind_core_packet_in_listener_register(ind_core_packet_in_listener_f fn)
+indigo_core_packet_in_listener_register(indigo_core_packet_in_listener_f fn)
 {
     if (biglist_find(packet_in_listeners, fn)) {
         return INDIGO_ERROR_EXISTS;
@@ -49,19 +49,19 @@ ind_core_packet_in_listener_register(ind_core_packet_in_listener_f fn)
 }
 
 void
-ind_core_packet_in_listener_unregister(ind_core_packet_in_listener_f fn)
+indigo_core_packet_in_listener_unregister(indigo_core_packet_in_listener_f fn)
 {
     packet_in_listeners = biglist_remove(packet_in_listeners, fn);
 }
 
-ind_core_listener_result_t
+indigo_core_listener_result_t
 ind_core_packet_in_notify(of_packet_in_t *packet_in)
 {
-    ind_core_listener_result_t result = IND_CORE_LISTENER_RESULT_PASS;
+    indigo_core_listener_result_t result = INDIGO_CORE_LISTENER_RESULT_PASS;
     biglist_t *cur;
-    ind_core_packet_in_listener_f fn;
+    indigo_core_packet_in_listener_f fn;
 
-    BIGLIST_FOREACH_DATA(cur, packet_in_listeners, ind_core_packet_in_listener_f, fn) {
+    BIGLIST_FOREACH_DATA(cur, packet_in_listeners, indigo_core_packet_in_listener_f, fn) {
         result |= fn(packet_in);
     }
 
@@ -71,7 +71,7 @@ ind_core_packet_in_notify(of_packet_in_t *packet_in)
 /* Port status */
 
 indigo_error_t
-ind_core_port_status_listener_register(ind_core_port_status_listener_f fn)
+indigo_core_port_status_listener_register(indigo_core_port_status_listener_f fn)
 {
     if (biglist_find(port_status_listeners, fn)) {
         return INDIGO_ERROR_EXISTS;
@@ -83,19 +83,19 @@ ind_core_port_status_listener_register(ind_core_port_status_listener_f fn)
 }
 
 void
-ind_core_port_status_listener_unregister(ind_core_port_status_listener_f fn)
+indigo_core_port_status_listener_unregister(indigo_core_port_status_listener_f fn)
 {
     port_status_listeners = biglist_remove(port_status_listeners, fn);
 }
 
-ind_core_listener_result_t
+indigo_core_listener_result_t
 ind_core_port_status_notify(of_port_status_t *port_status)
 {
-    ind_core_listener_result_t result = IND_CORE_LISTENER_RESULT_PASS;
+    indigo_core_listener_result_t result = INDIGO_CORE_LISTENER_RESULT_PASS;
     biglist_t *cur;
-    ind_core_port_status_listener_f fn;
+    indigo_core_port_status_listener_f fn;
 
-    BIGLIST_FOREACH_DATA(cur, port_status_listeners, ind_core_port_status_listener_f, fn) {
+    BIGLIST_FOREACH_DATA(cur, port_status_listeners, indigo_core_port_status_listener_f, fn) {
         result |= fn(port_status);
     }
 
@@ -105,7 +105,7 @@ ind_core_port_status_notify(of_port_status_t *port_status)
 /* Message from controller */
 
 indigo_error_t
-ind_core_message_listener_register(ind_core_message_listener_f fn)
+indigo_core_message_listener_register(indigo_core_message_listener_f fn)
 {
     if (biglist_find(message_listeners, fn)) {
         return INDIGO_ERROR_EXISTS;
@@ -117,19 +117,19 @@ ind_core_message_listener_register(ind_core_message_listener_f fn)
 }
 
 void
-ind_core_message_listener_unregister(ind_core_message_listener_f fn)
+indigo_core_message_listener_unregister(indigo_core_message_listener_f fn)
 {
     message_listeners = biglist_remove(message_listeners, fn);
 }
 
-ind_core_listener_result_t
+indigo_core_listener_result_t
 ind_core_message_notify(indigo_cxn_id_t cxn_id, of_object_t *message)
 {
-    ind_core_listener_result_t result = IND_CORE_LISTENER_RESULT_PASS;
+    indigo_core_listener_result_t result = INDIGO_CORE_LISTENER_RESULT_PASS;
     biglist_t *cur;
-    ind_core_message_listener_f fn;
+    indigo_core_message_listener_f fn;
 
-    BIGLIST_FOREACH_DATA(cur, message_listeners, ind_core_message_listener_f, fn) {
+    BIGLIST_FOREACH_DATA(cur, message_listeners, indigo_core_message_listener_f, fn) {
         result |= fn(cxn_id, message);
     }
 

--- a/modules/OFStateManager/module/src/listener.h
+++ b/modules/OFStateManager/module/src/listener.h
@@ -30,9 +30,9 @@
 #include <indigo/indigo.h>
 
 /* Notify functions for each class of listener */
-ind_core_listener_result_t ind_core_packet_in_notify(of_packet_in_t *packet_in);
-ind_core_listener_result_t ind_core_port_status_notify(of_port_status_t *port_status);
-ind_core_listener_result_t ind_core_message_notify(indigo_cxn_id_t cxn_id, of_object_t *message);
+indigo_core_listener_result_t ind_core_packet_in_notify(of_packet_in_t *packet_in);
+indigo_core_listener_result_t ind_core_port_status_notify(of_port_status_t *port_status);
+indigo_core_listener_result_t ind_core_message_notify(indigo_cxn_id_t cxn_id, of_object_t *message);
 
 #endif /* _OFSTATEMANAGER_LISTENER_H_ */
 

--- a/modules/OFStateManager/module/src/ofstatemanager.c
+++ b/modules/OFStateManager/module/src/ofstatemanager.c
@@ -110,7 +110,7 @@ indigo_core_packet_in(of_packet_in_t *packet_in)
     LOG_TRACE("Packet in rcvd");
     ind_core_packet_ins++;
 
-    if (ind_core_packet_in_notify(packet_in) == IND_CORE_LISTENER_RESULT_DROP) {
+    if (ind_core_packet_in_notify(packet_in) == INDIGO_CORE_LISTENER_RESULT_DROP) {
         LOG_TRACE("Listener dropped packet-in");
         of_object_delete(packet_in);
         return INDIGO_ERROR_NONE;
@@ -219,7 +219,7 @@ indigo_core_receive_controller_message(indigo_cxn_id_t cxn, of_object_t *obj)
     LOG_TRACE("Received %s message from cxn %d",
               of_object_id_str[obj->object_id], cxn);
 
-    if (ind_core_message_notify(cxn, obj) == IND_CORE_LISTENER_RESULT_DROP) {
+    if (ind_core_message_notify(cxn, obj) == INDIGO_CORE_LISTENER_RESULT_DROP) {
         LOG_TRACE("Listener dropped message");
         of_object_delete(obj);
         return;
@@ -940,7 +940,7 @@ indigo_core_port_status_update(of_port_status_t *of_port_status)
 
     LOG_TRACE("OF state mgr port status update");
 
-    if (ind_core_port_status_notify(of_port_status) == IND_CORE_LISTENER_RESULT_DROP) {
+    if (ind_core_port_status_notify(of_port_status) == INDIGO_CORE_LISTENER_RESULT_DROP) {
         LOG_TRACE("Listener dropped port status update");
         of_object_delete(of_port_status);
         return;

--- a/modules/OFStateManager/utest/main.c
+++ b/modules/OFStateManager/utest/main.c
@@ -1240,26 +1240,26 @@ test_flow_stats(void)
 
 struct listener_state {
     int count;
-    ind_core_listener_result_t result;
+    indigo_core_listener_result_t result;
 };
 
 struct listener_state listener_states[3];
 
-ind_core_listener_result_t
+indigo_core_listener_result_t
 listener0(void *arg)
 {
     listener_states[0].count++;
     return listener_states[0].result;
 }
 
-ind_core_listener_result_t
+indigo_core_listener_result_t
 listener1(void *arg)
 {
     listener_states[1].count++;
     return listener_states[1].result;
 }
 
-ind_core_listener_result_t
+indigo_core_listener_result_t
 listener2(void *arg)
 {
     listener_states[2].count++;
@@ -1272,17 +1272,17 @@ test_packet_in_listeners(void)
     memset(async_message_counters, 0, sizeof(async_message_counters));
 
     /* Register 3 listeners */
-    TEST_INDIGO_OK(ind_core_packet_in_listener_register(
-        (ind_core_packet_in_listener_f)listener0));
-    TEST_INDIGO_OK(ind_core_packet_in_listener_register(
-        (ind_core_packet_in_listener_f)listener1));
-    TEST_INDIGO_OK(ind_core_packet_in_listener_register(
-        (ind_core_packet_in_listener_f)listener2));
+    TEST_INDIGO_OK(indigo_core_packet_in_listener_register(
+        (indigo_core_packet_in_listener_f)listener0));
+    TEST_INDIGO_OK(indigo_core_packet_in_listener_register(
+        (indigo_core_packet_in_listener_f)listener1));
+    TEST_INDIGO_OK(indigo_core_packet_in_listener_register(
+        (indigo_core_packet_in_listener_f)listener2));
 
     memset(listener_states, 0, sizeof(listener_states));
-    listener_states[0].result = IND_CORE_LISTENER_RESULT_PASS;
-    listener_states[1].result = IND_CORE_LISTENER_RESULT_PASS;
-    listener_states[2].result = IND_CORE_LISTENER_RESULT_PASS;
+    listener_states[0].result = INDIGO_CORE_LISTENER_RESULT_PASS;
+    listener_states[1].result = INDIGO_CORE_LISTENER_RESULT_PASS;
+    listener_states[2].result = INDIGO_CORE_LISTENER_RESULT_PASS;
 
     /* Pass event through listeners */
     TEST_INDIGO_OK(indigo_core_packet_in(of_packet_in_new(OF_VERSION_1_0)));
@@ -1292,7 +1292,7 @@ test_packet_in_listeners(void)
     TEST_ASSERT(async_message_counters[OF_PACKET_IN] == 1);
 
     /* Drop event in one listener */
-    listener_states[1].result = IND_CORE_LISTENER_RESULT_DROP;
+    listener_states[1].result = INDIGO_CORE_LISTENER_RESULT_DROP;
     TEST_INDIGO_OK(indigo_core_packet_in(of_packet_in_new(OF_VERSION_1_0)));
     TEST_ASSERT(listener_states[0].count == 2);
     TEST_ASSERT(listener_states[1].count == 2);
@@ -1300,12 +1300,12 @@ test_packet_in_listeners(void)
     TEST_ASSERT(async_message_counters[OF_PACKET_IN] == 1);
 
     /* Unregister listeners */
-    ind_core_packet_in_listener_unregister(
-        (ind_core_packet_in_listener_f)listener1);
-    ind_core_packet_in_listener_unregister(
-        (ind_core_packet_in_listener_f)listener2);
-    ind_core_packet_in_listener_unregister(
-        (ind_core_packet_in_listener_f)listener0);
+    indigo_core_packet_in_listener_unregister(
+        (indigo_core_packet_in_listener_f)listener1);
+    indigo_core_packet_in_listener_unregister(
+        (indigo_core_packet_in_listener_f)listener2);
+    indigo_core_packet_in_listener_unregister(
+        (indigo_core_packet_in_listener_f)listener0);
 
     TEST_INDIGO_OK(indigo_core_packet_in(of_packet_in_new(OF_VERSION_1_0)));
     TEST_ASSERT(listener_states[0].count == 2);
@@ -1322,17 +1322,17 @@ test_port_status_listeners(void)
     memset(async_message_counters, 0, sizeof(async_message_counters));
 
     /* Register 3 listeners */
-    TEST_INDIGO_OK(ind_core_port_status_listener_register(
-        (ind_core_port_status_listener_f)listener0));
-    TEST_INDIGO_OK(ind_core_port_status_listener_register(
-        (ind_core_port_status_listener_f)listener1));
-    TEST_INDIGO_OK(ind_core_port_status_listener_register(
-        (ind_core_port_status_listener_f)listener2));
+    TEST_INDIGO_OK(indigo_core_port_status_listener_register(
+        (indigo_core_port_status_listener_f)listener0));
+    TEST_INDIGO_OK(indigo_core_port_status_listener_register(
+        (indigo_core_port_status_listener_f)listener1));
+    TEST_INDIGO_OK(indigo_core_port_status_listener_register(
+        (indigo_core_port_status_listener_f)listener2));
 
     memset(listener_states, 0, sizeof(listener_states));
-    listener_states[0].result = IND_CORE_LISTENER_RESULT_PASS;
-    listener_states[1].result = IND_CORE_LISTENER_RESULT_PASS;
-    listener_states[2].result = IND_CORE_LISTENER_RESULT_PASS;
+    listener_states[0].result = INDIGO_CORE_LISTENER_RESULT_PASS;
+    listener_states[1].result = INDIGO_CORE_LISTENER_RESULT_PASS;
+    listener_states[2].result = INDIGO_CORE_LISTENER_RESULT_PASS;
 
     /* Pass event through listeners */
     indigo_core_port_status_update(of_port_status_new(OF_VERSION_1_0));
@@ -1342,7 +1342,7 @@ test_port_status_listeners(void)
     TEST_ASSERT(async_message_counters[OF_PORT_STATUS] == 1);
 
     /* Drop event in one listener */
-    listener_states[1].result = IND_CORE_LISTENER_RESULT_DROP;
+    listener_states[1].result = INDIGO_CORE_LISTENER_RESULT_DROP;
     indigo_core_port_status_update(of_port_status_new(OF_VERSION_1_0));
     TEST_ASSERT(listener_states[0].count == 2);
     TEST_ASSERT(listener_states[1].count == 2);
@@ -1350,12 +1350,12 @@ test_port_status_listeners(void)
     TEST_ASSERT(async_message_counters[OF_PORT_STATUS] == 1);
 
     /* Unregister listeners */
-    ind_core_port_status_listener_unregister(
-        (ind_core_port_status_listener_f)listener1);
-    ind_core_port_status_listener_unregister(
-        (ind_core_port_status_listener_f)listener2);
-    ind_core_port_status_listener_unregister(
-        (ind_core_port_status_listener_f)listener0);
+    indigo_core_port_status_listener_unregister(
+        (indigo_core_port_status_listener_f)listener1);
+    indigo_core_port_status_listener_unregister(
+        (indigo_core_port_status_listener_f)listener2);
+    indigo_core_port_status_listener_unregister(
+        (indigo_core_port_status_listener_f)listener0);
 
     indigo_core_port_status_update(of_port_status_new(OF_VERSION_1_0));
     TEST_ASSERT(listener_states[0].count == 2);
@@ -1372,17 +1372,17 @@ test_message_listeners(void)
     memset(controller_message_counters, 0, sizeof(controller_message_counters));
 
     /* Register 3 listeners */
-    TEST_INDIGO_OK(ind_core_message_listener_register(
-        (ind_core_message_listener_f)listener0));
-    TEST_INDIGO_OK(ind_core_message_listener_register(
-        (ind_core_message_listener_f)listener1));
-    TEST_INDIGO_OK(ind_core_message_listener_register(
-        (ind_core_message_listener_f)listener2));
+    TEST_INDIGO_OK(indigo_core_message_listener_register(
+        (indigo_core_message_listener_f)listener0));
+    TEST_INDIGO_OK(indigo_core_message_listener_register(
+        (indigo_core_message_listener_f)listener1));
+    TEST_INDIGO_OK(indigo_core_message_listener_register(
+        (indigo_core_message_listener_f)listener2));
 
     memset(listener_states, 0, sizeof(listener_states));
-    listener_states[0].result = IND_CORE_LISTENER_RESULT_PASS;
-    listener_states[1].result = IND_CORE_LISTENER_RESULT_PASS;
-    listener_states[2].result = IND_CORE_LISTENER_RESULT_PASS;
+    listener_states[0].result = INDIGO_CORE_LISTENER_RESULT_PASS;
+    listener_states[1].result = INDIGO_CORE_LISTENER_RESULT_PASS;
+    listener_states[2].result = INDIGO_CORE_LISTENER_RESULT_PASS;
 
     /* Pass event through listeners */
     handle_message(of_features_request_new(OF_VERSION_1_0));
@@ -1392,7 +1392,7 @@ test_message_listeners(void)
     TEST_ASSERT(controller_message_counters[OF_FEATURES_REPLY] == 1);
 
     /* Drop event in one listener */
-    listener_states[1].result = IND_CORE_LISTENER_RESULT_DROP;
+    listener_states[1].result = INDIGO_CORE_LISTENER_RESULT_DROP;
     handle_message(of_features_request_new(OF_VERSION_1_0));
     TEST_ASSERT(listener_states[0].count == 2);
     TEST_ASSERT(listener_states[1].count == 2);
@@ -1400,12 +1400,12 @@ test_message_listeners(void)
     TEST_ASSERT(controller_message_counters[OF_FEATURES_REPLY] == 1);
 
     /* Unregister listeners */
-    ind_core_message_listener_unregister(
-        (ind_core_message_listener_f)listener1);
-    ind_core_message_listener_unregister(
-        (ind_core_message_listener_f)listener2);
-    ind_core_message_listener_unregister(
-        (ind_core_message_listener_f)listener0);
+    indigo_core_message_listener_unregister(
+        (indigo_core_message_listener_f)listener1);
+    indigo_core_message_listener_unregister(
+        (indigo_core_message_listener_f)listener2);
+    indigo_core_message_listener_unregister(
+        (indigo_core_message_listener_f)listener0);
 
     handle_message(of_features_request_new(OF_VERSION_1_0));
     TEST_ASSERT(listener_states[0].count == 2);

--- a/modules/indigo/module/inc/indigo/of_state_manager.h
+++ b/modules/indigo/module/inc/indigo/of_state_manager.h
@@ -294,5 +294,44 @@ indigo_core_gentable_register(
 void
 indigo_core_gentable_unregister(indigo_core_gentable_t *gentable);
 
+
+/**
+ * Listener interfaces
+ *
+ * These functions allow modules not defined in the Indigo architecture to
+ * react to dataplane events and controller messages. This is useful for
+ * implementing add-on switch functionality like LACP and LLDP offloads.
+ */
+
+/**
+ * If any listener returns DROP, the event will not be handled by
+ * OFStateManager. All listeners will still see the event.
+ */
+typedef enum indigo_core_listener_result {
+    INDIGO_CORE_LISTENER_RESULT_PASS = 0,
+    INDIGO_CORE_LISTENER_RESULT_DROP = 1,
+} indigo_core_listener_result_t;
+
+/**
+ * Packet-in listener registration
+ */
+typedef indigo_core_listener_result_t (*indigo_core_packet_in_listener_f)(of_packet_in_t *packet_in);
+indigo_error_t indigo_core_packet_in_listener_register(indigo_core_packet_in_listener_f fn);
+void indigo_core_packet_in_listener_unregister(indigo_core_packet_in_listener_f fn);
+
+/**
+ * Port status listener registration
+ */
+typedef indigo_core_listener_result_t (*indigo_core_port_status_listener_f)(of_port_status_t *port_status);
+indigo_error_t indigo_core_port_status_listener_register(indigo_core_port_status_listener_f fn);
+void indigo_core_port_status_listener_unregister(indigo_core_port_status_listener_f fn);
+
+/**
+ * Message listener registration
+ */
+typedef indigo_core_listener_result_t (*indigo_core_message_listener_f)(indigo_cxn_id_t cxn_id, of_object_t *msg);
+indigo_error_t indigo_core_message_listener_register(indigo_core_message_listener_f fn);
+void indigo_core_message_listener_unregister(indigo_core_message_listener_f fn);
+
 #endif /* _INDIGO_OF_STATE_MANAGER_H_ */
 /** @} */


### PR DESCRIPTION
Reviewer: trivial

This removes the need to compile code that uses the listeners against the 
OFStateManager headers, so we can stub them out in unit tests.

This pull request just renames existing functions, type, etc. I'll update
switchlight-common to use the new names as soon as it goes in.
