### PR TITLE
OFStateManager: do not send error message when deleting a nonexistent gentable entry

### DIFF
--- a/modules/OFStateManager/module/src/gentable_handlers.c
+++ b/modules/OFStateManager/module/src/gentable_handlers.c
@@ -307,11 +307,7 @@ ind_core_bsn_gentable_entry_delete_handler(
 
     entry = find_entry_by_key(gentable, &key);
     if (entry == NULL) {
-        AIM_LOG_ERROR("Nonexistent %s gentable entry", gentable->name);
-        indigo_cxn_send_error_reply(
-            cxn_id, obj,
-            OF_ERROR_TYPE_BAD_REQUEST,
-            OF_REQUEST_FAILED_EPERM);
+        AIM_LOG_TRACE("Nonexistent %s gentable entry", gentable->name);
         of_object_delete(obj);
         return;
     }


### PR DESCRIPTION
Reviewer: @rlane

Behavior changed in https://github.com/floodlight/loxigen/pull/193
