### PR TITLE
making conditional optimization for loci module

### DIFF
--- a/modules/loci/make.mk
+++ b/modules/loci/make.mk
@@ -28,7 +28,9 @@ LOCI := $(SUBMODULE_LOXIGEN_ARTIFACTS)/loci
 
 loci_INCLUDES := -I $(LOCI)/inc
 loci_INTERNAL_INCLUDES := -I $(LOCI)/src
+ifndef DEBUG
 loci_CFLAGS := -Os
+endif
 
 LIBRARY := loci
 loci_SUBDIR := $(LOCI)/src


### PR DESCRIPTION
Do not enable -Os optimization when DEBUG is set.

This is making the assumption that you don't want optimization when debugging, which seems reasonable :)
