### PR TITLE
OFConnectionManager: always return a version from indigo_cxn_get_async_version

### DIFF
--- a/modules/OFConnectionManager/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager.c
@@ -1822,7 +1822,7 @@ indigo_cxn_get_async_version(of_version_t* of_version)
 
     /* If there's no controller we still need to send the packet-in through the
      * agents */
-    *of_version = OF_VERSION_1_3;
+    *of_version = IND_CXN_DEFAULT_ASYNC_MESSAGE_VERSION;
     return INDIGO_ERROR_NONE;
 }
 

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
@@ -53,6 +53,11 @@
     } while (0)
 
 /**
+ * Version used for async messages when no controller is connected.
+ */
+#define IND_CXN_DEFAULT_ASYNC_MESSAGE_VERSION OF_VERSION_1_3
+
+/**
  * Does the connection manager have a local connection?
  */
 extern int have_local_connection;


### PR DESCRIPTION
Reviewer: @poolakiran @harshsin

Even if no controller is connected the packet-in still needs to go to the 
agents.

It's clear now that we should replace indigo_core_packet_in, and similar 
functions, with interfaces that are version-independent.
