### PR TITLE
OFStateManager: don't send zero debug counters

### DIFF
--- a/modules/OFStateManager/module/src/bsn_debug_counter_handlers.c
+++ b/modules/OFStateManager/module/src/bsn_debug_counter_handlers.c
@@ -117,6 +117,10 @@ ind_core_bsn_debug_counter_stats_request_handler(of_object_t *_obj,
     LIST_FOREACH(counters, cur) {
         debug_counter_t *counter = container_of(cur, links, debug_counter_t);
 
+        if (debug_counter_get(counter) == 0) {
+            continue;
+        }
+
         of_bsn_debug_counter_stats_entry_counter_id_set(entry, counter->counter_id);
         of_bsn_debug_counter_stats_entry_value_set(entry, debug_counter_get(counter));
 


### PR DESCRIPTION
Reviewer: @harshsin

We're now keeping hundreds of counters per connection, about half of which
will always be zero. The clients aren't interested in zero counters, and if
they were they could infer their existence from the desc stats reply.
