### PR TITLE
OFStateManager: convert duplicate flow-add to modify

### DIFF
--- a/modules/OFStateManager/module/src/ft.c
+++ b/modules/OFStateManager/module/src/ft.c
@@ -212,6 +212,27 @@ ft_delete(ft_instance_t ft, ft_entry_t *entry)
     debug_counter_inc(&ft_delete_counter);
 }
 
+void
+ft_overwrite(ft_instance_t ft, ft_entry_t *entry, of_flow_add_t *flow_add)
+{
+    ft_checksum_update(ft, entry);
+    ft_entry_unlink(ft, entry);
+
+    of_flow_add_cookie_get(flow_add, &entry->cookie);
+    of_flow_add_flags_get(flow_add, &entry->flags);
+    of_flow_add_idle_timeout_get(flow_add, &entry->idle_timeout);
+    of_flow_add_hard_timeout_get(flow_add, &entry->hard_timeout);
+
+    indigo_error_t err = ft_entry_set_effects(entry, flow_add);
+    AIM_ASSERT(err == INDIGO_ERROR_NONE);
+
+    entry->insert_time = INDIGO_CURRENT_TIME;
+    entry->last_counter_change = entry->insert_time;
+
+    ft_entry_link(ft, entry);
+    ft_checksum_update(ft, entry);
+}
+
 indigo_error_t
 ft_strict_match(ft_instance_t instance,
                of_meta_match_t *query,

--- a/modules/OFStateManager/module/src/ft.h
+++ b/modules/OFStateManager/module/src/ft.h
@@ -212,6 +212,17 @@ indigo_error_t ft_add(ft_instance_t ft,
 void ft_delete(ft_instance_t ft, ft_entry_t *entry);
 
 /**
+ * Overwrite an existing flow entry in the table
+ * @param ft The flow table handle
+ * @param entry Pointer to the entry to be overwritten
+ * @param flow_add The LOCI flow mod object resulting in the overwrite
+ *
+ * This function updates the cookie, flags, timeouts, instructions, and
+ * creation time, as specified in OpenFlow 1.3.3 section 6.4.
+ */
+void ft_overwrite(ft_instance_t ft, ft_entry_t *entry, of_flow_add_t *flow_add);
+
+/**
  * Query the flow table (strict match) and return the first match if found
  * @param ft Handle for a flow table instance
  * @param query The meta-match data for the query

--- a/modules/OFStateManager/module/src/handlers.c
+++ b/modules/OFStateManager/module/src/handlers.c
@@ -354,9 +354,30 @@ ind_core_flow_add_handler(of_object_t *_obj, indigo_cxn_id_t cxn_id)
         return;
     }
 
-    /* Delete existing flow if any */
     if (ft_strict_match(ind_core_ft, &query, &entry) == INDIGO_ERROR_NONE) {
-        ind_core_flow_entry_delete(entry, INDIGO_FLOW_REMOVED_OVERWRITE);
+        if (obj->version == OF_VERSION_1_0) {
+            /* Delete existing flow */
+            ind_core_flow_entry_delete(entry, INDIGO_FLOW_REMOVED_OVERWRITE);
+        } else {
+            /* Overwrite existing flow */
+            LOG_TRACE("Overwriting existing flow");
+            ind_core_table_t *table = ind_core_table_get(entry->table_id);
+            if (table != NULL) {
+                rv = table->ops->entry_modify(table->priv, entry->priv, obj);
+            } else {
+                rv = indigo_fwd_flow_modify(entry->id, obj);
+            }
+
+            if (rv == INDIGO_ERROR_NONE) {
+                ft_overwrite(ind_core_ft, entry, obj);
+            } else {
+                LOG_ERROR("Error from Forwarding while modifying flow: %d",
+                          indigo_strerror(rv));
+                flow_mod_err_msg_send(rv, obj->version, cxn_id, obj);
+            }
+
+            return;
+        }
     }
 
     /* No match found, add as normal */


### PR DESCRIPTION
Reviewer: @wilmo119

Previously we deleted existing flows when the controller added a new one with 
the same match and priority. This was incorrect for a couple of reasons.
First, the OpenFlow 1.3 spec says that stats should be preserved and
flow-removed messages should not be generated for this case. Second, if an
error occured adding the new flow then the switch would end up in a state
where neither flow is present. Finally, doing a delete followed by an add can
cause brief traffic loss.
