### PR TITLE
OFConnectionManager: batched message processing

### DIFF
--- a/modules/OFConnectionManager/module/auto/OFConnectionManager.yml
+++ b/modules/OFConnectionManager/module/auto/OFConnectionManager.yml
@@ -51,6 +51,9 @@ cdefs: &cdefs
 - OFCONNECTIONMANAGER_CONFIG_OF_VERSION:
     doc: "OpenFlow version to be advertised in HELLO message"
     default: OF_VERSION_1_0
+- OFCONNECTIONMANAGER_CONFIG_MAX_MSGS_PER_TICK:
+    doc: "Maximum number of OpenFlow messages to process per socket in one tick of the event loop."
+    default: 10
 
 definitions:
   cdefs:

--- a/modules/OFConnectionManager/module/inc/OFConnectionManager/ofconnectionmanager_config.h
+++ b/modules/OFConnectionManager/module/inc/OFConnectionManager/ofconnectionmanager_config.h
@@ -129,6 +129,16 @@
 #define OFCONNECTIONMANAGER_CONFIG_OF_VERSION OF_VERSION_1_0
 #endif
 
+/**
+ * OFCONNECTIONMANAGER_CONFIG_MAX_MSGS_PER_TICK
+ *
+ * Maximum number of OpenFlow messages to process per socket in one tick of the event loop. */
+
+
+#ifndef OFCONNECTIONMANAGER_CONFIG_MAX_MSGS_PER_TICK
+#define OFCONNECTIONMANAGER_CONFIG_MAX_MSGS_PER_TICK 10
+#endif
+
 
 
 /**

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager_config.c
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager_config.c
@@ -86,6 +86,11 @@ ofconnectionmanager_config_settings_t ofconnectionmanager_config_settings[] =
 #else
 { OFCONNECTIONMANAGER_CONFIG_OF_VERSION(__ofconnectionmanager_config_STRINGIFY_NAME), "__undefined__" },
 #endif
+#ifdef OFCONNECTIONMANAGER_CONFIG_MAX_MSGS_PER_TICK
+    { __ofconnectionmanager_config_STRINGIFY_NAME(OFCONNECTIONMANAGER_CONFIG_MAX_MSGS_PER_TICK), __ofconnectionmanager_config_STRINGIFY_VALUE(OFCONNECTIONMANAGER_CONFIG_MAX_MSGS_PER_TICK) },
+#else
+{ OFCONNECTIONMANAGER_CONFIG_MAX_MSGS_PER_TICK(__ofconnectionmanager_config_STRINGIFY_NAME), "__undefined__" },
+#endif
     { NULL, NULL }
 };
 #undef __ofconnectionmanager_config_STRINGIFY_VALUE


### PR DESCRIPTION
Reviewer: @harshsin

Long ago, Indigo processed messages from a socket as long as data was 
available. This was potentially unbounded and caused problems in practice
where the switch processed hundreds of messages from one connection before
moving on to other tasks. Back then I changed it to process a single message
at a time.

This change reduces the overhead per message while retaining fairness. We 
process at most 10 (or 10 ms, whichever comes first) worth of messages from 
each connection.

This increases performance in my barrier benchmark by 140%.
