### PR TITLE
SocketManager: restrict priority range

### DIFF
--- a/modules/Configuration/module/src/sighup.c
+++ b/modules/Configuration/module/src/sighup.c
@@ -59,5 +59,5 @@ ind_cfg_install_sighup_handler(void)
     (void) signal(SIGHUP, sighup);
 
     return ind_soc_socket_register_with_priority(
-        pipefd[0], sighup_callback, NULL, 20);
+        pipefd[0], sighup_callback, NULL, IND_SOC_HIGHEST_PRIORITY);
 }

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
@@ -86,7 +86,7 @@ connection_t* cookie_to_cxn(void* cookie);
 /*
  * Priority for sockets and timers registered with SocketManager.
  */
-#define IND_CXN_EVENT_PRIORITY 10
+#define IND_CXN_EVENT_PRIORITY IND_SOC_HIGH_PRIORITY
 
 extern void indigo_cxn_socket_ready_callback(int socket_id,
                                              void *cookie,

--- a/modules/OFStateManager/module/src/expiration.c
+++ b/modules/OFStateManager/module/src/expiration.c
@@ -171,7 +171,7 @@ ind_core_expiration_timer(void *cookie)
     }
 
     if ((rv = ind_soc_task_register(expiration_task, NULL,
-                                    IND_SOC_DEFAULT_PRIORITY)) < 0) {
+                                    IND_SOC_NORMAL_PRIORITY)) < 0) {
         AIM_LOG_ERROR("Failed to start flow expiration task: %s",
                       indigo_strerror(rv));
     } else {

--- a/modules/OFStateManager/module/src/gentable_handlers.c
+++ b/modules/OFStateManager/module/src/gentable_handlers.c
@@ -384,7 +384,7 @@ ind_core_bsn_gentable_clear_request_handler(
     indigo_cxn_block_barrier(cxn_id, &state->blocker);
 
     rv = ind_core_gentable_spawn_iter_task(gentable, clear_iter, state,
-                                           IND_SOC_DEFAULT_PRIORITY,
+                                           IND_SOC_NORMAL_PRIORITY,
                                            checksum, checksum_mask);
     if (rv < 0) {
         AIM_LOG_ERROR("Failed to spawn gentable iter task: %s", indigo_strerror(rv));
@@ -560,7 +560,7 @@ ind_core_bsn_gentable_entry_stats_request_handler(
     state->reply = reply;
 
     rv = ind_core_gentable_spawn_iter_task(gentable, entry_stats_iter, state,
-                                           IND_SOC_DEFAULT_PRIORITY,
+                                           IND_SOC_NORMAL_PRIORITY,
                                            checksum, checksum_mask);
     if (rv < 0) {
         AIM_LOG_ERROR("Failed to spawn gentable iter task: %s", indigo_strerror(rv));
@@ -656,7 +656,7 @@ ind_core_bsn_gentable_entry_desc_stats_request_handler(
     state->reply = reply;
 
     rv = ind_core_gentable_spawn_iter_task(gentable, entry_desc_stats_iter, state,
-                                           IND_SOC_DEFAULT_PRIORITY,
+                                           IND_SOC_NORMAL_PRIORITY,
                                            checksum, checksum_mask);
     if (rv < 0) {
         AIM_LOG_ERROR("Failed to spawn gentable iter task: %s", indigo_strerror(rv));

--- a/modules/OFStateManager/module/src/handlers.c
+++ b/modules/OFStateManager/module/src/handlers.c
@@ -604,7 +604,7 @@ ind_core_flow_modify_handler(of_object_t *_obj, indigo_cxn_id_t cxn_id)
     indigo_cxn_block_barrier(cxn_id, &state->blocker);
 
     rv = ft_spawn_iter_task(ind_core_ft, &query, modify_iter_cb, state,
-                            IND_SOC_DEFAULT_PRIORITY);
+                            IND_SOC_NORMAL_PRIORITY);
     if (rv != INDIGO_ERROR_NONE) {
         indigo_cxn_unblock_barrier(&state->blocker);
         of_object_delete(state->request);
@@ -711,7 +711,7 @@ ind_core_flow_delete_handler(of_object_t *obj, indigo_cxn_id_t cxn_id)
     indigo_cxn_block_barrier(cxn_id, &state->blocker);
 
     rv = ft_spawn_iter_task(ind_core_ft, &query, delete_iter_cb, state,
-                            IND_SOC_DEFAULT_PRIORITY);
+                            IND_SOC_NORMAL_PRIORITY);
     if (rv != INDIGO_ERROR_NONE) {
         indigo_cxn_unblock_barrier(&state->blocker);
         aim_free(state);
@@ -952,7 +952,7 @@ ind_core_flow_stats_request_handler(of_object_t *_obj, indigo_cxn_id_t cxn_id)
     indigo_cxn_block_barrier(cxn_id, &state->blocker);
 
     rv = ft_spawn_iter_task(ind_core_ft, &query, ind_core_flow_stats_iter,
-                            state, IND_SOC_DEFAULT_PRIORITY);
+                            state, IND_SOC_NORMAL_PRIORITY);
     if (rv != INDIGO_ERROR_NONE) {
         LOG_ERROR("Failed to start flow stats iter: %s", indigo_strerror(rv));
         indigo_cxn_unblock_barrier(&state->blocker);
@@ -1062,7 +1062,7 @@ ind_core_aggregate_stats_request_handler(of_object_t *_obj,
     indigo_cxn_block_barrier(cxn_id, &state->blocker);
 
     rv = ft_spawn_iter_task(ind_core_ft, &query, ind_core_aggregate_stats_iter,
-                            state, IND_SOC_DEFAULT_PRIORITY);
+                            state, IND_SOC_NORMAL_PRIORITY);
     if (rv != INDIGO_ERROR_NONE) {
         LOG_ERROR("Failed to start aggregate stats iter: %s", indigo_strerror(rv));
         indigo_cxn_unblock_barrier(&state->blocker);

--- a/modules/OFStateManager/module/src/ofstatemanager.c
+++ b/modules/OFStateManager/module/src/ofstatemanager.c
@@ -740,7 +740,7 @@ ind_core_enable_set(int enable)
         if (CORE_EXPIRES_FLOWS(&ind_core_config)) {
             ind_soc_timer_event_register_with_priority(
                 ind_core_expiration_timer, NULL,
-                ind_core_config.stats_check_ms, -10);
+                ind_core_config.stats_check_ms, IND_SOC_LOW_PRIORITY);
         }
         ind_core_module_enabled = 1;
     } else if (!enable && ind_core_module_enabled) {

--- a/modules/OFStateManager/utest/main.c
+++ b/modules/OFStateManager/utest/main.c
@@ -942,7 +942,7 @@ test_ft_iter_task(void)
     TEST_INDIGO_OK(ft_add(ft, 2, flow_add2, &entry2));
 
     state = (struct iter_task_state) { .ft = ft, .finished = -1, .entries_seen = 0 };
-    ft_spawn_iter_task(ft, NULL, iter_task_cb, &state, IND_SOC_DEFAULT_PRIORITY);
+    ft_spawn_iter_task(ft, NULL, iter_task_cb, &state, IND_SOC_NORMAL_PRIORITY);
     TEST_ASSERT(state.finished == -1);
     TEST_ASSERT(state.entries_seen == 0);
     TEST_ASSERT(ft->current_count == 2);

--- a/modules/SocketManager/module/inc/SocketManager/socketmanager.h
+++ b/modules/SocketManager/module/inc/SocketManager/socketmanager.h
@@ -44,12 +44,18 @@
  * Socket register functions
  ****************************************************************/
 
-/*
- * Priorities are signed integers. Higher priority events are handled first.
+/**
+ * Priority
+ *
+ * Higher priority events are handled first.
  */
-#define IND_SOC_DEFAULT_PRIORITY 0
-#define IND_SOC_HIGHEST_PRIORITY INT_MAX
-#define IND_SOC_LOWEST_PRIORITY  INT_MIN
+typedef enum ind_soc_priority_e {
+    IND_SOC_LOWEST_PRIORITY,
+    IND_SOC_LOW_PRIORITY,
+    IND_SOC_NORMAL_PRIORITY,
+    IND_SOC_HIGH_PRIORITY,
+    IND_SOC_HIGHEST_PRIORITY,
+} ind_soc_priority_t;
 
 /**
  * Run status.
@@ -101,7 +107,7 @@ indigo_error_t ind_soc_socket_register_with_priority(
     int socket_id,
     ind_soc_socket_ready_callback_f callback,
     void *cookie,
-    int priority);
+    ind_soc_priority_t priority);
 
 /**
  * Register a socket for processing by the socket manager
@@ -111,7 +117,7 @@ indigo_error_t ind_soc_socket_register_with_priority(
  * @param cookie Data to pass to the callback
  *
  * This is a wrapper around ind_soc_socket_register_with_priority which
- * passes IND_SOC_DEFAULT_PRIORITY for the priority.
+ * passes IND_SOC_NORMAL_PRIORITY for the priority.
  *
  * Provided by socket manager, required by various
  */
@@ -221,7 +227,7 @@ indigo_error_t ind_soc_timer_event_register_with_priority(
     ind_soc_timer_callback_f callback,
     void *cookie,
     int repeat_time_ms,
-    int priority);
+    ind_soc_priority_t priority);
 
 /**
  * Register a timer event
@@ -232,7 +238,7 @@ indigo_error_t ind_soc_timer_event_register_with_priority(
  *                       or IND_SOC_TIMER_IMMEDIATE
  *
  * This function is a wrapper around ind_soc_timer_event_register which passes
- * IND_SOC_DEFAULT_PRIORITY for the priority.
+ * IND_SOC_NORMAL_PRIORITY for the priority.
  */
 
 indigo_error_t ind_soc_timer_event_register(
@@ -282,7 +288,7 @@ typedef ind_soc_task_status_t (*ind_soc_task_callback_f)(void *cookie);
 
 indigo_error_t ind_soc_task_register(
     ind_soc_task_callback_f callback,
-    void *cookie, int priority);
+    void *cookie, ind_soc_priority_t priority);
 
 
 typedef struct ind_soc_config_s {

--- a/modules/SocketManager/utest/main.c
+++ b/modules/SocketManager/utest/main.c
@@ -527,33 +527,33 @@ test_priority(void)
 
     /* High priority */
     INDIGO_ASSERT(ind_soc_socket_register_with_priority(
-        read_fds[0], socket_callback, &counters[0], 1) == 0);
+        read_fds[0], socket_callback, &counters[0], IND_SOC_HIGH_PRIORITY) == 0);
 
     INDIGO_ASSERT(ind_soc_timer_event_register_with_priority(
-        timer_callback, &timer_counters[0], IND_SOC_TIMER_IMMEDIATE, 1) == 0);
+        timer_callback, &timer_counters[0], IND_SOC_TIMER_IMMEDIATE, IND_SOC_HIGH_PRIORITY) == 0);
 
     INDIGO_ASSERT(ind_soc_task_register(
-        task_callback, &task_counters[0], 1) == 0);
+        task_callback, &task_counters[0], IND_SOC_HIGH_PRIORITY) == 0);
 
     /* Medium priority */
     INDIGO_ASSERT(ind_soc_socket_register_with_priority(
-        read_fds[1], socket_callback, &counters[1], 0) == 0);
+        read_fds[1], socket_callback, &counters[1], IND_SOC_NORMAL_PRIORITY) == 0);
 
     INDIGO_ASSERT(ind_soc_timer_event_register_with_priority(
-        timer_callback, &timer_counters[1], IND_SOC_TIMER_IMMEDIATE, 0) == 0);
+        timer_callback, &timer_counters[1], IND_SOC_TIMER_IMMEDIATE, IND_SOC_NORMAL_PRIORITY) == 0);
 
     INDIGO_ASSERT(ind_soc_task_register(
-        task_callback, &task_counters[1], 0) == 0);
+        task_callback, &task_counters[1], IND_SOC_NORMAL_PRIORITY) == 0);
 
     /* Low priority */
     INDIGO_ASSERT(ind_soc_socket_register_with_priority(
-        read_fds[2], socket_callback, &counters[2], -1) == 0);
+        read_fds[2], socket_callback, &counters[2], IND_SOC_LOW_PRIORITY) == 0);
 
     INDIGO_ASSERT(ind_soc_timer_event_register_with_priority(
-        timer_callback, &timer_counters[2], IND_SOC_TIMER_IMMEDIATE, -1) == 0);
+        timer_callback, &timer_counters[2], IND_SOC_TIMER_IMMEDIATE, IND_SOC_LOW_PRIORITY) == 0);
 
     INDIGO_ASSERT(ind_soc_task_register(
-        task_callback, &task_counters[2], -1) == 0);
+        task_callback, &task_counters[2], IND_SOC_LOW_PRIORITY) == 0);
 
     /* Make all sockets ready */
     for (i = 0; i < 3; i++) {
@@ -593,7 +593,7 @@ test_priority(void)
     /* New high priority events should run next */
     write(write_fds[0], "x", 1);
     INDIGO_ASSERT(ind_soc_task_register(
-        task_callback, &task_counters[0], 1) == 0);
+        task_callback, &task_counters[0], IND_SOC_HIGH_PRIORITY) == 0);
     memset(counters, 0, sizeof(counters));
     memset(timer_counters, 0, sizeof(timer_counters));
     memset(task_counters, 0, sizeof(task_counters));


### PR DESCRIPTION
Reviewer: @poolakiran

Previously SocketManager supported 4 billion priority levels, but we only ever 
used a few of them. There are some optimizations I want to make that will be 
simpler if we can restrict the number of possible priorities. This change 
limits users to 5 named priorities.
