### PR TITLE
OFConnectionManager: fix permissions check for group-mod messages

### DIFF
--- a/modules/OFConnectionManager/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager/module/src/cxn_instance.c
@@ -972,7 +972,9 @@ of_msg_process(connection_t *cxn, of_object_t *obj)
     case OF_BSN_SET_IP_MASK:
     case OF_BSN_SET_MIRRORING:
     case OF_BSN_SET_PKTIN_SUPPRESSION_REQUEST:
-    case OF_GROUP_MOD:
+    case OF_GROUP_ADD:
+    case OF_GROUP_MODIFY:
+    case OF_GROUP_DELETE:
         if (cxn->controller->role == INDIGO_CXN_R_SLAVE) {
             uint16_t code = cxn->status.negotiated_version < OF_VERSION_1_2 ?
                 OF_REQUEST_FAILED_EPERM : OF_REQUEST_FAILED_IS_SLAVE;


### PR DESCRIPTION
Reviewer: trivial

When we changed the group-mod message to an inheritance hierarchy we didn't 
update this function.
