### PR TITLE
OFStateManager: fix undeclared variable in assertion

### DIFF
--- a/modules/OFStateManager/module/src/ft.c
+++ b/modules/OFStateManager/module/src/ft.c
@@ -223,10 +223,7 @@ ft_overwrite(ft_instance_t ft, ft_entry_t *entry, of_flow_add_t *flow_add)
     of_flow_add_idle_timeout_get(flow_add, &entry->idle_timeout);
     of_flow_add_hard_timeout_get(flow_add, &entry->hard_timeout);
 
-#ifndef NDEBUG
-    indigo_error_t err =
-#endif
-        ft_entry_set_effects(entry, flow_add);
+    indigo_error_t err = ft_entry_set_effects(entry, flow_add);
     AIM_ASSERT(err == INDIGO_ERROR_NONE);
 
     entry->insert_time = INDIGO_CURRENT_TIME;


### PR DESCRIPTION
Reviewer: trivial

Now that asserts reference the expression even when the assert is disabled, 
this hack is no longer needed.
