### PR TITLE
OFConnectionManager: drop more types of messages when the write buffer partially fills

### DIFF
--- a/modules/OFConnectionManager/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager/module/src/cxn_instance.c
@@ -1574,6 +1574,14 @@ ind_cxn_register_debug_counters(connection_t *cxn)
     int i;
     const int skip = 3; /* "of_" prefix */
 
+    {
+        char name[DEBUG_COUNTER_NAME_SIZE];
+        aim_snprintf(name, sizeof(name), "cxn." CXN_FMT ".tx_drop", CXN_FMT_ARGS(cxn));
+        name[sizeof(name)-1] = '\0';
+        char *description = "Outgoing message dropped by the switch due to long send queue";
+        debug_counter_register(&cxn->tx_drop_counter, aim_strdup(name), description);
+    }
+
     for (i = 0; i < OF_MESSAGE_OBJECT_COUNT; i++) {
         char name[DEBUG_COUNTER_NAME_SIZE];
         aim_snprintf(name, sizeof(name), "cxn." CXN_FMT ".rx.%s", CXN_FMT_ARGS(cxn), of_object_id_str[i]+skip);
@@ -1595,6 +1603,12 @@ void
 ind_cxn_unregister_debug_counters(connection_t *cxn)
 {
     int i;
+
+    {
+        char *name = (char *) cxn->tx_drop_counter.name;
+        debug_counter_unregister(&cxn->tx_drop_counter);
+        aim_free(name);
+    }
 
     for (i = 0; i < OF_MESSAGE_OBJECT_COUNT; i++) {
         debug_counter_t *counter = &cxn->rx_counters[i];

--- a/modules/OFConnectionManager/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager/module/src/cxn_instance.h
@@ -51,6 +51,11 @@
 #define WRITE_BUFFER_SIZE (16 * 1024 * 1024)
 
 /**
+ * Write queue length above which to drop noncritical messages
+ */
+#define NONCRITICAL_DROP_THRESHOLD 64
+
+/**
  * Connection flag, connection is to be removed pending op completion
  */
 #define CXN_TO_BE_REMOVED 0x1
@@ -113,10 +118,9 @@ typedef struct connection_s {
     int pkts_enqueued;      /* Total pkts queued */
 
     /* Additional debug info */
+    debug_counter_t tx_drop_counter;
     debug_counter_t rx_counters[OF_MESSAGE_OBJECT_COUNT];
     debug_counter_t tx_counters[OF_MESSAGE_OBJECT_COUNT];
-
-    uint64_t packet_ins;
 
     int outstanding_op_cnt; /* Number of outstanding operations */
     struct {
@@ -147,21 +151,6 @@ typedef struct connection_s {
     /* Pointer to the Controller clock to which this connection belongs */
     controller_t *controller;
 } connection_t;
-
-/* Should a packet in be dropped based on connection state?
- * @TODO This may need tuning
- */
-#define PACKET_IN_DROP_QUEUE_MAX 64
-#define CXN_DROP_PACKET_IN(cxn, obj)                    \
-    ((cxn)->pkts_enqueued > PACKET_IN_DROP_QUEUE_MAX)
-
-/**
- * Should a flow removed message be dropped based on connection state?
- * @TODO This may need tuning
- */
-#define FLOW_REMOVED_DROP_QUEUE_MAX 64
-#define CXN_DROP_FLOW_REMOVED(cxn, obj)                \
-    ((cxn)->pkts_enqueued > FLOW_REMOVED_DROP_QUEUE_MAX)
 
 /**
  * How many bytes in buffer are free

--- a/modules/indigo/module/inc/indigo/of_connection_manager.h
+++ b/modules/indigo/module/inc/indigo/of_connection_manager.h
@@ -206,7 +206,6 @@ typedef enum indigo_cxn_role_e {
 /**
  * Status of a connection instance.
  *    state The current connection state (see indigo_cxn_state_t)
- *    role The HA role, if applicable; only valid if state is CONNECTED
  *    negotiated_version If connected, the version used by the connection
  *    disconnect_count Number of times controller has disconnected from switch
  *    forced_disconnect_count Number of times the switch disconnected
@@ -226,8 +225,6 @@ typedef struct indigo_cxn_status_s {
     uint64_t bytes_out;
     uint64_t messages_in;
     uint64_t messages_out;
-    uint64_t packet_in_drop;
-    uint64_t flow_removed_drop;
 } indigo_cxn_status_t;
 
 /****************************************************************


### PR DESCRIPTION
Reviewer: @harshsin

Refactored to classify certain message types as "noncritical" and drop them 
when reaching a high water mark.

Previously only OF_FLOW_REMOVED and OF_PACKET_IN would be dropped. This adds 
OF_BSN_FLOW_IDLE, OF_BSN_ARP_IDLE, and OF_BSN_PDU_RX_TIMEOUT.
