### PR TITLE
OFStateManager: fix flow checksum use of table_id

### DIFF
--- a/modules/OFStateManager/module/src/ft.c
+++ b/modules/OFStateManager/module/src/ft.c
@@ -658,6 +658,12 @@ ft_entry_create(indigo_flow_id_t id, of_flow_add_t *flow_add, ft_entry_t **entry
     entry->insert_time = INDIGO_CURRENT_TIME;
     entry->last_counter_change = entry->insert_time;
 
+    if (flow_add->version >= OF_VERSION_1_1) {
+        of_flow_add_table_id_get(flow_add, &entry->table_id);
+    } else {
+        entry->table_id = 0;
+    }
+
     *entry_p = entry;
 
     return INDIGO_ERROR_NONE;

--- a/modules/OFStateManager/module/src/handlers.c
+++ b/modules/OFStateManager/module/src/handlers.c
@@ -315,7 +315,6 @@ ind_core_flow_add_handler(of_object_t *_obj, indigo_cxn_id_t cxn_id)
     ft_entry_t        *entry = 0;
     indigo_flow_id_t  flow_id;
     uint16_t idle_timeout, hard_timeout;
-    uint8_t table_id;
 
     ver = obj->version;
 
@@ -391,23 +390,18 @@ ind_core_flow_add_handler(of_object_t *_obj, indigo_cxn_id_t cxn_id)
         return;
     }
 
-    table_id = 0;
-    if (obj->version >= OF_VERSION_1_1) {
-        of_flow_add_table_id_get(obj, &table_id);
-    }
-
-    ind_core_table_t *table = ind_core_table_get(table_id);
+    ind_core_table_t *table = ind_core_table_get(entry->table_id);
     if (table != NULL) {
         rv = table->ops->entry_create(table->priv, cxn_id,
                                       obj, flow_id, &entry->priv);
     } else {
-        rv = indigo_fwd_flow_create(flow_id, (of_flow_add_t *)obj, &table_id);
+        uint8_t ignored_table_id;
+        rv = indigo_fwd_flow_create(flow_id, (of_flow_add_t *)obj, &ignored_table_id);
     }
 
     if (rv == INDIGO_ERROR_NONE) {
         LOG_TRACE("Flow table now has %d entries",
                   ind_core_ft->current_count);
-        entry->table_id = table_id;
     } else { /* Error during insertion at forwarding layer */
        uint32_t xid;
 

--- a/modules/indigo/module/inc/indigo/forwarding.h
+++ b/modules/indigo/module/inc/indigo/forwarding.h
@@ -58,7 +58,7 @@ extern indigo_error_t indigo_fwd_forwarding_features_get(
 /**
  * @brief Flow create
  * @param of_flow_add The original LOCI request
- * @param [out] table_id Table inserted into
+ * @param [out] table_id Table inserted into (ignored)
  *
  * Create a flow for the forwarding engine.
  *


### PR DESCRIPTION
Reviewer: @harshsin

The bsn_flow_checksum extension uses the table id to determine which table and 
bucket checksums to update. The checksum update is done in ft_add, which uses 
entry->table_id. However, ft_entry_create was not initializing the table_id 
fields. Instead, for OF 1.1+, the table id was set after the call to 
indigo_fwd_flow_create. This was to support the OF 1.0 feature where the 
switch could choose which table to insert the flow into.

The new flowtable API does not support returning a table id, and no Indigo 
switches use this feature. I'm removing it. The new code is simpler and 
initializes table_id when the flow checksum code expects it to.
