### PR TITLE
OFConnectionManager: send controller connections async message on role change

### DIFF
--- a/modules/OFConnectionManager/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager/module/src/cxn_instance.c
@@ -643,6 +643,8 @@ nicira_controller_role_request_handle(connection_t *cxn, of_object_t *_obj)
                      cxn->controller->controller_id, role_to_string(role));
             cxn->controller->role = role;
         }
+
+        ind_cxn_status_notify();
     }
 
     of_nicira_controller_role_reply_xid_set(reply, xid);
@@ -734,6 +736,8 @@ role_request_handle(connection_t *cxn, of_object_t *_obj)
                 LOG_INFO(cxn, "Setting role to %s", role_to_string(role));
                 cxn->controller->role = role;
             }
+
+            ind_cxn_status_notify();
         }
     }
 

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager.c
@@ -69,8 +69,6 @@ static void
 ind_cxn_listen_socket_ready(int socket_id, void *cookie, int read_ready,
                             int write_ready, int error_seen);
 
-static void ind_cxn_status_notify(void);
-
 /****************************************************************
  * Connection Manager Data shared within module
  ****************************************************************/
@@ -429,7 +427,7 @@ ind_cxn_status_change(connection_t *cxn)
  * HACK reusing the reply message for this async notification.
  */
 
-static void
+void
 ind_cxn_status_notify(void)
 {
     of_version_t version;

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
@@ -110,6 +110,8 @@ int ind_aux_connection_add(connection_t *cxn, uint32_t num_aux);
 
 void ind_controller_disconnect(controller_t *ctrl);
 
+void ind_cxn_status_notify(void);
+
 /**
  * The OF message callback vector from state manager
  */


### PR DESCRIPTION
Reviewer: @kenchiang

This was previously only being sent on a connection status change.
