### PR TITLE
OFStateManager: remove support for expiring flows in Forwarding

### DIFF
--- a/modules/OFStateManager/module/inc/OFStateManager/ofstatemanager.h
+++ b/modules/OFStateManager/module/inc/OFStateManager/ofstatemanager.h
@@ -48,7 +48,6 @@
 #define IND_CORE_SERIAL_NUM_DEFAULT "11235813213455"
 
 typedef struct ind_core_config_s {
-    int expire_flows;   /**< Boolean, should state mgr manage flow expires */
     int stats_check_ms; /**< How frequently to check stats for expire, etc */
     indigo_core_disconnected_mode_t disconnected_mode;
     int max_flowtable_entries; /**< Maximum number of entries in the flowtable */

--- a/modules/OFStateManager/module/src/handlers.c
+++ b/modules/OFStateManager/module/src/handlers.c
@@ -832,8 +832,6 @@ ind_core_flow_stats_iter(void *cookie, ft_entry_t *entry)
     }
 
     indigo_fi_flow_stats_t flow_stats = {
-        .flow_id = entry->id,
-        .duration_ns = 0,
         .packets = -1,
         .bytes = -1,
     };
@@ -989,8 +987,6 @@ ind_core_aggregate_stats_iter(void *cookie, ft_entry_t *entry)
 
     if (entry != NULL) {
         indigo_fi_flow_stats_t flow_stats = {
-            .flow_id = entry->id,
-            .duration_ns = 0,
             .packets = -1,
             .bytes = -1,
         };

--- a/modules/OFStateManager/utest/main.c
+++ b/modules/OFStateManager/utest/main.c
@@ -1452,7 +1452,6 @@ aim_main(int argc, char* argv[])
 
     /* Init Core */
     MEMSET(&core, 0, sizeof(core));
-    core.expire_flows = 1;
     core.stats_check_ms = 1000;
     core.max_flowtable_entries = 1024;
 

--- a/modules/indigo/module/inc/indigo/fi.h
+++ b/modules/indigo/module/inc/indigo/fi.h
@@ -54,15 +54,9 @@ typedef enum indigo_fi_flow_removed_e {
 
 /**
  * @brief Flow statistics counters
- *
- * Not all implementations will support duration_ns.  It must be 0 if not used.
- * It is provided for implementations that do timing events such as flow
- * expirations in the forwarding module.
  */
 
 typedef struct indigo_fi_flow_stats {
-    indigo_flow_id_t flow_id; /**< The ID of the flow */
-    uint64_t duration_ns;     /**< Time in ns flow exists or existed */
     uint64_t packets;         /**< Number of packets in flow  */
     uint64_t bytes;           /**< Number of bytes in flow  */
 } indigo_fi_flow_stats_t;

--- a/modules/indigo/module/inc/indigo/forwarding.h
+++ b/modules/indigo/module/inc/indigo/forwarding.h
@@ -178,13 +178,6 @@ extern indigo_error_t indigo_fwd_experimenter(
     of_experimenter_t *experimenter,
     indigo_cxn_id_t cxn_id);
 
-
-/**
- * Notify forwarding of changes in expiration processing behavior
- */
-extern indigo_error_t indigo_fwd_expiration_enable_set(int is_enabled);
-extern indigo_error_t indigo_fwd_expiration_enable_get(int *is_enabled);
-
 /**
  * Group management
  *

--- a/modules/indigo/module/inc/indigo/of_state_manager.h
+++ b/modules/indigo/module/inc/indigo/of_state_manager.h
@@ -128,33 +128,6 @@ extern indigo_error_t indigo_core_dpid_get(of_dpid_t *dpid);
  */
 extern void indigo_core_port_status_update(of_port_status_t *port_status);
 
-
-/****************************************************************
- * Asynchronous forwarding flow removed event notification call
- *
- ****************************************************************/
-
-/**
- * @brief Notify state manager that a flow has been removed
- * @param reason The reason the flow was removed.  See fi.h.
- * @param stats A stats structure identifying the flow and related info
- *
- * This call is made from forwarding to the state manager to indicate
- * that a flow has been removed for some reason.
- *
- * Not all implementations may support this.  It is provided for
- * those which may do all flow expiration processing in the
- * forwarding module, and for those which may evict flows due
- * to resource or other constraints.
- *
- * It is not recommended that this call be made if a flow was removed because
- * of a call from the state manager to indigo_fwd_flow_delete.
- */
-
-extern void indigo_core_flow_removed(
-    indigo_fi_flow_removed_t reason,
-    indigo_fi_flow_stats_t *stats);
-
 /****************************************************************
  * Asynchronous connection manager notification, disconnection mode
  ****************************************************************/


### PR DESCRIPTION
Reviewer: @wilmo119 

None of our switches do this, and a switch that did would have to reimplement
a bunch of expiration.c to ratelimit the flow-removed messages and send
flow-idle notifications when necessary.

Once we're fully transitioned to the new flowtable APIs, ind_core_flow_removed 
would be the only remaining user of the flow-id hashtable.
