### PR TITLE
OFConnectionManager: add notifications for barriers

### DIFF
--- a/modules/OFConnectionManager/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager/module/src/cxn_instance.c
@@ -577,6 +577,10 @@ barrier_request_handle(connection_t *cxn, of_object_t *_obj)
     ind_cxn_pause(cxn);
     cxn->barrier.pendingf = 1;
 
+    /* Notify other modules to finish their delayed processing and unblock the
+     * barrier */
+    ind_cxn_barrier_notify(cxn->cxn_id);
+
     return (INDIGO_ERROR_NONE);
 }
 

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
@@ -154,6 +154,9 @@ extern void ind_cxn_stats_show(aim_pvs_t* pvs, int details);
 
 extern const struct ind_cfg_ops ind_cxn_cfg_ops;
 
+/* Run all barrier notify callbacks */
+void ind_cxn_barrier_notify(indigo_cxn_id_t cxn_id);
+
 #include <OFConnectionManager/ofconnectionmanager.h>
 
 #endif /* __OFCONNECTIONMANAGER_INT_H__ */

--- a/modules/indigo/module/inc/indigo/of_connection_manager.h
+++ b/modules/indigo/module/inc/indigo/of_connection_manager.h
@@ -531,5 +531,39 @@ void indigo_cxn_pause(indigo_cxn_id_t cxn_id);
  */
 void indigo_cxn_resume(indigo_cxn_id_t cxn_id);
 
+/**
+ * Barrier notification callback
+ *
+ * @param cxn_id Connection ID where the barrier was received
+ * @param cookie Passed in on register
+ */
+
+typedef void (*indigo_cxn_barrier_notify_f)(
+    indigo_cxn_id_t              cxn_id,
+    void                         *cookie);
+
+/**
+ * Register a barrier notification handler
+ * @param handler The handler to register
+ * @param cookie Anonymous data passed back to handler
+ *
+ * Registered functions are called when any connection receives a barrier
+ * and barriers on that connection are currently blocked.
+ */
+void indigo_cxn_barrier_notify_register(
+    indigo_cxn_barrier_notify_f handler,
+    void *cookie);
+
+/**
+ * Unregister a barrier notification handler
+ * @param handler The handler to unregister
+ * @param cookie Cookie associated with handler
+ *
+ * The cookie is part of the lookup key
+ */
+void indigo_cxn_barrier_notify_unregister(
+    indigo_cxn_barrier_notify_f handler,
+    void *cookie);
+
 #endif /* _INDIGO_OF_CONNECTION_MANAGER_H_ */
 /* @} */


### PR DESCRIPTION
Reviewer: @harshsin

Some modules may wish to defer work until a barrier is received. This new 
interface allows them to register to be notify when a (blocked) barrier
arrives on a connection. The module should then decide whether it holds a
barrier blocker on that connection, and if so finish its work and unblock the
barrier.
