### PR TITLE
Fix bugs in logging and socket write

### DIFF
--- a/modules/OFConnectionManager/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager/module/src/cxn_instance.c
@@ -265,11 +265,15 @@ cxn_state_set(connection_t *cxn, indigo_cxn_state_t new_state)
     }
 
     if (!CXN_LOCAL(cxn)) {
-        LOG_INFO(cxn, "%s->%s", CXN_STATE_NAME(old_state),
-                 CXN_STATE_NAME(new_state));
+        LOG_INFO(cxn, "%s->%s (id "CXN_ID_FMT")",
+                 CXN_STATE_NAME(old_state),
+                 CXN_STATE_NAME(new_state),
+                 CXN_ID_FMT_ARGS(cxn->cxn_id));
     } else {
-        LOG_LOCAL(cxn, "%s->%s", CXN_STATE_NAME(old_state),
-                  CXN_STATE_NAME(new_state));
+        LOG_LOCAL(cxn, "%s->%s (id "CXN_ID_FMT")",
+                  CXN_STATE_NAME(old_state),
+                  CXN_STATE_NAME(new_state),
+                  CXN_ID_FMT_ARGS(cxn->cxn_id));
     }
 
     /****************************************************************

--- a/modules/OFConnectionManager/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager/module/src/cxn_instance.h
@@ -87,6 +87,11 @@
  */
 #define CXN_ID_GENERATION_SHIFT 16
 #define CXN_ID_TO_INDEX(cxn_id) ((cxn_id) & ((1<<CXN_ID_GENERATION_SHIFT)-1))
+#define CXN_ID_TO_GENERATION(cxn_id) ((cxn_id) >> CXN_ID_GENERATION_SHIFT)
+
+/* Format a connection id as index:generation */
+#define CXN_ID_FMT "%u:%u"
+#define CXN_ID_FMT_ARGS(cxn_id) CXN_ID_TO_INDEX(cxn_id), CXN_ID_TO_GENERATION(cxn_id)
 
 /* Controller control block */
 typedef struct controller_s {

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager.c
@@ -641,7 +641,8 @@ ind_cxn_connection_remove(indigo_cxn_id_t cxn_id)
     connection_t *cxn = cxn_id_to_connection(cxn_id);
 
     if (!cxn) {
-        LOG_ERROR("Attempted to remove nonexistent connection");
+        LOG_ERROR("Attempted to remove nonexistent connection " CXN_ID_FMT,
+                  CXN_ID_FMT_ARGS(cxn_id));
         return INDIGO_ERROR_NOT_FOUND;
     }
 
@@ -875,7 +876,8 @@ indigo_cxn_connection_config_get(
     connection_t *cxn = CXN_ID_TO_CONNECTION(cxn_id);
 
     if (!cxn) {
-        LOG_WARN("Attempted to get config for a nonexistent connection");
+        LOG_WARN("Attempted to get config for nonexistent connection " CXN_ID_FMT,
+                 CXN_ID_FMT_ARGS(cxn_id));
         return INDIGO_ERROR_NOT_FOUND;
     }
 
@@ -895,7 +897,8 @@ indigo_cxn_connection_status_get(
     connection_t *cxn = CXN_ID_TO_CONNECTION(cxn_id);
 
     if (!cxn) {
-        LOG_WARN("Attempted to get status for a nonexistent connection");
+        LOG_WARN("Attempted to get status for nonexistent connection " CXN_ID_FMT,
+                 CXN_ID_FMT_ARGS(cxn_id));
         return INDIGO_ERROR_NOT_FOUND;
     }
 
@@ -1067,8 +1070,8 @@ indigo_cxn_send_controller_message(indigo_cxn_id_t cxn_id, of_object_t *obj)
 
     cxn = CXN_ID_TO_CONNECTION(cxn_id);
     if (!cxn || !CXN_TCP_CONNECTED(cxn)) {
-        LOG_VERBOSE("Attempted to send %s message to disconnected connection",
-                    of_object_id_str[obj->object_id]);
+        LOG_VERBOSE("Attempted to send %s message to disconnected connection " CXN_ID_FMT,
+                    of_object_id_str[obj->object_id], CXN_ID_FMT_ARGS(cxn_id));
         goto done;
     }
 
@@ -1431,7 +1434,8 @@ indigo_cxn_send_error_reply(indigo_cxn_id_t cxn_id, of_object_t *orig,
 
     connection_t *cxn = CXN_ID_TO_CONNECTION(cxn_id);
     if (cxn == NULL) {
-        LOG_ERROR("Failed to send error message, connection no longer exists");
+        LOG_ERROR("Attempted to send error message to nonexistent connection " CXN_ID_FMT,
+                  CXN_ID_FMT_ARGS(cxn_id));
         return;
     }
 
@@ -1665,7 +1669,7 @@ ind_cxn_reset(indigo_cxn_id_t cxn_id)
         return;
     }
 
-    LOG_VERBOSE("Connection reset for id %d", cxn_id);
+    LOG_VERBOSE("Connection reset for id " CXN_ID_FMT, CXN_ID_FMT_ARGS(cxn_id));
     if (cxn_id == IND_CXN_RESET_ALL) {
         /* Iterate thru active controllers and reset all but listening */
         indigo_controller_id_t id;
@@ -1818,7 +1822,8 @@ indigo_cxn_get_auxiliary_id(indigo_cxn_id_t cxn_id, uint8_t *auxiliary_id)
     connection_t *cxn = CXN_ID_TO_CONNECTION(cxn_id);
 
     if (cxn == NULL) {
-        LOG_ERROR("Attempted to get auxiliary ID of a nonexistent connection");
+        LOG_ERROR("Attempted to get auxiliary ID of nonexistent connection " CXN_ID_FMT,
+                  CXN_ID_FMT_ARGS(cxn_id));
         return INDIGO_ERROR_NOT_FOUND;
     }
 


### PR DESCRIPTION
Reviewer: @kenchiang

I also did a cleanup pass over ofconnectionmanager.c removing unnecessary and error-prone uses of the connection ID.
