### PR TITLE
SocketManager: make maximum number of timers configurable

### DIFF
--- a/modules/SocketManager/module/auto/SocketManager.yml
+++ b/modules/SocketManager/module/auto/SocketManager.yml
@@ -57,6 +57,9 @@ cdefs: &cdefs
 - SOCKETMANAGER_CONFIG_TIMER_PEEK_MS:
     doc: "Milliseconds to look ahead for the next timer"
     default: 1024
+- SOCKETMANAGER_CONFIG_MAX_SOCKETS:
+    doc: "Maximum number of sockets supported"
+    default: 1024
 
 
 definitions:

--- a/modules/SocketManager/module/inc/SocketManager/socketmanager_config.h
+++ b/modules/SocketManager/module/inc/SocketManager/socketmanager_config.h
@@ -148,6 +148,16 @@
 #define SOCKETMANAGER_CONFIG_TIMER_PEEK_MS 1024
 #endif
 
+/**
+ * SOCKETMANAGER_CONFIG_MAX_SOCKETS
+ *
+ * Maximum number of sockets supported */
+
+
+#ifndef SOCKETMANAGER_CONFIG_MAX_SOCKETS
+#define SOCKETMANAGER_CONFIG_MAX_SOCKETS 1024
+#endif
+
 
 
 /**

--- a/modules/SocketManager/module/src/socketmanager.c
+++ b/modules/SocketManager/module/src/socketmanager.c
@@ -71,8 +71,6 @@ static int module_enabled = 0;
 
 #define INVALID_SOCKET_ID -1
 
-/* Maximum simultaneous sockets to support */
-#define SOCKET_COUNT_MAX 1024
 typedef struct soc_map_s {
     short socket_id;
     uint16_t pollfd_index;
@@ -82,14 +80,14 @@ typedef struct soc_map_s {
 } soc_map_t;
 
 /* Indexed by socket descriptor */
-static soc_map_t soc_map[SOCKET_COUNT_MAX];
+static soc_map_t soc_map[SOCKETMANAGER_CONFIG_MAX_SOCKETS];
 
 /* Dense array passed to poll(2) */
-static struct pollfd pollfds[SOCKET_COUNT_MAX];
+static struct pollfd pollfds[SOCKETMANAGER_CONFIG_MAX_SOCKETS];
 static int num_pollfds = 0;
 
 #define IS_ACTIVE_SOCKET_ID(_id) (soc_map[_id].socket_id == (_id))
-#define IS_LEGAL_SOCKET_ID(_id) (((_id) >= 0) && ((_id) < SOCKET_COUNT_MAX))
+#define IS_LEGAL_SOCKET_ID(_id) (((_id) >= 0) && ((_id) < SOCKETMANAGER_CONFIG_MAX_SOCKETS))
 #define POLLFD_INDEX(_id) soc_map[(_id)].pollfd_index
 
 enum timer_state {
@@ -178,7 +176,7 @@ static void
 soc_mgr_init(void)
 {
     int idx;
-    for (idx = 0; idx < SOCKET_COUNT_MAX; idx++) {
+    for (idx = 0; idx < SOCKETMANAGER_CONFIG_MAX_SOCKETS; idx++) {
         soc_map[idx].socket_id = INVALID_SOCKET_ID;
     }
 
@@ -225,7 +223,7 @@ ind_soc_socket_register_with_priority(int socket_id,
     soc_map[socket_id].cookie = cookie;
     soc_map[socket_id].priority = priority;
 
-    INDIGO_ASSERT(num_pollfds < SOCKET_COUNT_MAX);
+    INDIGO_ASSERT(num_pollfds < SOCKETMANAGER_CONFIG_MAX_SOCKETS);
     pfd = &pollfds[num_pollfds++];
     pfd->fd = socket_id;
     pfd->events = POLLIN;

--- a/modules/SocketManager/module/src/socketmanager_config.c
+++ b/modules/SocketManager/module/src/socketmanager_config.c
@@ -94,6 +94,11 @@ socketmanager_config_settings_t socketmanager_config_settings[] =
 #else
 { SOCKETMANAGER_CONFIG_TIMER_PEEK_MS(__socketmanager_config_STRINGIFY_NAME), "__undefined__" },
 #endif
+#ifdef SOCKETMANAGER_CONFIG_MAX_SOCKETS
+    { __socketmanager_config_STRINGIFY_NAME(SOCKETMANAGER_CONFIG_MAX_SOCKETS), __socketmanager_config_STRINGIFY_VALUE(SOCKETMANAGER_CONFIG_MAX_SOCKETS) },
+#else
+{ SOCKETMANAGER_CONFIG_MAX_SOCKETS(__socketmanager_config_STRINGIFY_NAME), "__undefined__" },
+#endif
     { NULL, NULL }
 };
 #undef __socketmanager_config_STRINGIFY_VALUE


### PR DESCRIPTION
Reviewer: @harshsin

1024 is too low for IVS given that we use several file descriptors per port.
