### PR TITLE
Port lookup/refcount functionality from group table to gentables

### DIFF
--- a/modules/OFStateManager/module/src/gentable_handlers.c
+++ b/modules/OFStateManager/module/src/gentable_handlers.c
@@ -85,6 +85,7 @@ struct ind_core_gentable_entry {
     of_list_bsn_tlv_t *key;
     of_list_bsn_tlv_t *value;
     of_checksum_128_t checksum;
+    uint32_t refcount;
 };
 
 static indigo_core_gentable_t *gentables[MAX_GENTABLES];
@@ -871,6 +872,10 @@ delete_entry(indigo_core_gentable_t *gentable, struct ind_core_gentable_entry *e
     indigo_error_t rv;
     struct ind_core_gentable_checksum_bucket *checksum_bucket;
 
+    if (entry->refcount > 0) {
+        return INDIGO_ERROR_EXISTS;
+    }
+
     rv = gentable->ops->del(gentable->priv, entry->priv, entry->key);
     if (rv < 0) {
         return rv;
@@ -1076,4 +1081,30 @@ indigo_core_gentable_lookup(indigo_core_gentable_t *gentable, of_object_t *key)
     }
 
     return entry->priv;
+}
+
+void *
+indigo_core_gentable_acquire(indigo_core_gentable_t *gentable, of_object_t *key)
+{
+    struct ind_core_gentable_entry *entry = find_entry_by_key(gentable, key);
+    if (entry == NULL) {
+        return NULL;
+    }
+
+    AIM_TRUE_OR_DIE(entry->refcount < UINT32_MAX);
+    entry->refcount++;
+    return entry->priv;
+}
+
+void
+indigo_core_gentable_release(indigo_core_gentable_t *gentable, of_object_t *key)
+{
+    struct ind_core_gentable_entry *entry = find_entry_by_key(gentable, key);
+    if (entry == NULL) {
+        AIM_LOG_INTERNAL("attempted to release nonexistent entry in gentable %s", gentable->name);
+        return;
+    }
+
+    AIM_ASSERT(entry->refcount >= 1);
+    entry->refcount--;
 }

--- a/modules/indigo/module/inc/indigo/of_state_manager.h
+++ b/modules/indigo/module/inc/indigo/of_state_manager.h
@@ -240,6 +240,33 @@ indigo_core_gentable_unregister(indigo_core_gentable_t *gentable);
 void *
 indigo_core_gentable_lookup(indigo_core_gentable_t *gentable, of_object_t *key);
 
+/*
+ * @brief Acquire a reference to a gentable entry
+ * @param gentable
+ * @param key
+ *
+ * Returns the private data for the entry, or NULL if not found.
+ *
+ * The key can be either a single TLV or a list of TLVs.
+ *
+ * Delete operations on the gentable entry will be rejected until all
+ * references to it are released.
+ */
+
+void *
+indigo_core_gentable_acquire(indigo_core_gentable_t *gentable, of_object_t *key);
+
+/*
+ * @brief Release a reference to a gentable entry
+ * @param gentable
+ * @param key
+ *
+ * The key can be either a single TLV or a list of TLVs.
+ */
+
+void
+indigo_core_gentable_release(indigo_core_gentable_t *gentable, of_object_t *key);
+
 
 /**
  * Listener interfaces


### PR DESCRIPTION
Reviewer: @kenchiang 

These APIs allow callers to look up gentable entries by key without needing to maintain their own hashtable, by reusing the hashtable that already exists. Just like with the group table, the acquire/release functions allow code to store pointers to entry private data.
