### PR TITLE
OFStateManager: pass cxn_id to gentable operations

### DIFF
--- a/modules/OFStateManager/utest/gentable_test.c
+++ b/modules/OFStateManager/utest/gentable_test.c
@@ -557,7 +557,7 @@ parse_value(of_list_bsn_tlv_t *value, of_mac_addr_t *mac)
 }
 
 static indigo_error_t
-test_gentable_add(void *table_priv, of_list_bsn_tlv_t *key, of_list_bsn_tlv_t *value, void **entry_priv)
+test_gentable_add(indigo_cxn_id_t cxn_id, void *table_priv, of_list_bsn_tlv_t *key, of_list_bsn_tlv_t *value, void **entry_priv)
 {
     struct test_table *table = table_priv;
 
@@ -581,7 +581,7 @@ test_gentable_add(void *table_priv, of_list_bsn_tlv_t *key, of_list_bsn_tlv_t *v
 }
 
 static indigo_error_t
-test_gentable_modify(void *table_priv, void *entry_priv, of_list_bsn_tlv_t *key, of_list_bsn_tlv_t *value)
+test_gentable_modify(indigo_cxn_id_t cxn_id, void *table_priv, void *entry_priv, of_list_bsn_tlv_t *key, of_list_bsn_tlv_t *value)
 {
     struct test_table *table = table_priv;
 
@@ -605,7 +605,7 @@ test_gentable_modify(void *table_priv, void *entry_priv, of_list_bsn_tlv_t *key,
 }
 
 static indigo_error_t
-test_gentable_delete(void *table_priv, void *entry_priv, of_list_bsn_tlv_t *key)
+test_gentable_delete(indigo_cxn_id_t cxn_id, void *table_priv, void *entry_priv, of_list_bsn_tlv_t *key)
 {
     struct test_table *table = table_priv;
 
@@ -665,8 +665,8 @@ test_gentable_get_stats(void *table_priv, void *entry_priv, of_list_bsn_tlv_t *k
 }
 
 static indigo_core_gentable_ops_t test_ops = {
-    test_gentable_add,
-    test_gentable_modify,
-    test_gentable_delete,
-    test_gentable_get_stats,
+    .add2 = test_gentable_add,
+    .modify2 = test_gentable_modify,
+    .del2 = test_gentable_delete,
+    .get_stats = test_gentable_get_stats,
 };

--- a/modules/indigo/module/inc/indigo/of_state_manager.h
+++ b/modules/indigo/module/inc/indigo/of_state_manager.h
@@ -194,6 +194,44 @@ typedef struct indigo_core_gentable_ops {
     void (*get_stats)(
         void *table_priv, void *entry_priv, of_list_bsn_tlv_t *key,
         of_list_bsn_tlv_t *stats);
+
+    /**
+     * @brief Add an entry
+     * @param cxn_id Controller connection ID
+     * @param table_priv Table private data
+     * @param key Entry key
+     * @param value Entry value
+     * @param [out] entry_priv Opaque private data for the entry, passed back
+     *                         whenever another operation is made on the entry.
+     */
+    indigo_error_t (*add2)(
+        indigo_cxn_id_t cxn_id,
+        void *table_priv, of_list_bsn_tlv_t *key, of_list_bsn_tlv_t *value,
+        void **entry_priv);
+
+    /**
+     * @brief Modify an entry
+     * @param cxn_id Controller connection ID
+     * @param table_priv Table private data
+     * @param entry_priv Entry private data
+     * @param key Entry key (identical to key from add)
+     * @param value New entry value
+     */
+    indigo_error_t (*modify2)(
+        indigo_cxn_id_t cxn_id,
+        void *table_priv, void *entry_priv, of_list_bsn_tlv_t *key,
+        of_list_bsn_tlv_t *value);
+
+    /**
+     * @brief Delete an entry
+     * @param cxn_id Controller connection ID
+     * @param table_priv Table private data
+     * @param entry_priv Entry private data
+     * @param key Entry key (identical to key from add)
+     */
+    indigo_error_t (*del2)(
+        indigo_cxn_id_t cxn_id,
+        void *table_priv, void *entry_priv, of_list_bsn_tlv_t *key);
 } indigo_core_gentable_ops_t;
 
 /*


### PR DESCRIPTION
Reviewer: @poolakiran 

The cxn_id is needed for barrier blocking.

Backwards compatibility is maintained since this adds new function pointers
that are used in preference to the old ones. The old function pointers are now
deprecated and will be removed when all callers are switched over.
