### PR TITLE
OFStateManager: add API to get table ID assigned to a gentable

### DIFF
--- a/modules/OFStateManager/module/src/gentable_handlers.c
+++ b/modules/OFStateManager/module/src/gentable_handlers.c
@@ -1121,3 +1121,9 @@ indigo_core_gentable_release(indigo_core_gentable_t *gentable, of_object_t *key)
     AIM_ASSERT(entry->refcount >= 1);
     entry->refcount--;
 }
+
+uint16_t
+indigo_core_gentable_id(indigo_core_gentable_t *gentable)
+{
+    return gentable->table_id;
+}

--- a/modules/OFStateManager/utest/gentable_test.c
+++ b/modules/OFStateManager/utest/gentable_test.c
@@ -86,6 +86,7 @@ test_gentable_entry_add(void)
 
     memset(&table, 0, sizeof(table));
     indigo_core_gentable_register(name, &test_ops, &table, 10, 8, &gentable);
+    AIM_TRUE_OR_DIE(indigo_core_gentable_id(gentable) == TABLE_ID);
     AIM_TRUE_OR_DIE(table.count_op == 0);
 
     memset(&table, 0, sizeof(table));
@@ -120,6 +121,7 @@ test_gentable_entry_delete(void)
 
     memset(&table, 0, sizeof(table));
     indigo_core_gentable_register(name, &test_ops, &table, 10, 8, &gentable);
+    AIM_TRUE_OR_DIE(indigo_core_gentable_id(gentable) == TABLE_ID);
     AIM_TRUE_OR_DIE(table.count_op == 0);
 
     memset(&table, 0, sizeof(table));
@@ -155,6 +157,7 @@ test_gentable_entry_modify(void)
 
     memset(&table, 0, sizeof(table));
     indigo_core_gentable_register(name, &test_ops, &table, 10, 8, &gentable);
+    AIM_TRUE_OR_DIE(indigo_core_gentable_id(gentable) == TABLE_ID);
     AIM_TRUE_OR_DIE(table.count_op == 0);
 
     do_add(1, mac1, 0);
@@ -183,6 +186,7 @@ test_gentable_clear(void)
 
     memset(&table, 0, sizeof(table));
     indigo_core_gentable_register(name, &test_ops, &table, 10, 8, &gentable);
+    AIM_TRUE_OR_DIE(indigo_core_gentable_id(gentable) == TABLE_ID);
     AIM_TRUE_OR_DIE(table.count_op == 0);
 
     do_add(1, mac1, 0);
@@ -212,6 +216,7 @@ test_gentable_entry_stats(void)
 
     memset(&table, 0, sizeof(table));
     indigo_core_gentable_register(name, &test_ops, &table, 10, 8, &gentable);
+    AIM_TRUE_OR_DIE(indigo_core_gentable_id(gentable) == TABLE_ID);
     AIM_TRUE_OR_DIE(table.count_op == 0);
 
     do_add(1, mac1, 0);
@@ -242,6 +247,7 @@ test_gentable_long_running_task(void)
 
     memset(&table, 0, sizeof(table));
     indigo_core_gentable_register(name, &test_ops, &table, 10, 4, &gentable);
+    AIM_TRUE_OR_DIE(indigo_core_gentable_id(gentable) == TABLE_ID);
     AIM_TRUE_OR_DIE(table.count_op == 0);
 
     /* Two entries per checksum bucket */
@@ -310,6 +316,7 @@ test_gentable_lookup(void)
 
     memset(&table, 0, sizeof(table));
     indigo_core_gentable_register(name, &test_ops, &table, 10, 8, &gentable);
+    AIM_TRUE_OR_DIE(indigo_core_gentable_id(gentable) == TABLE_ID);
     AIM_TRUE_OR_DIE(table.count_op == 0);
 
     do_add(1, mac1, 0);
@@ -346,6 +353,7 @@ test_gentable_acquire(void)
 
     memset(&table, 0, sizeof(table));
     indigo_core_gentable_register(name, &test_ops, &table, 10, 8, &gentable);
+    AIM_TRUE_OR_DIE(indigo_core_gentable_id(gentable) == TABLE_ID);
     AIM_TRUE_OR_DIE(table.count_op == 0);
 
     /* Acquire/release an entry */

--- a/modules/indigo/module/inc/indigo/of_state_manager.h
+++ b/modules/indigo/module/inc/indigo/of_state_manager.h
@@ -305,6 +305,16 @@ indigo_core_gentable_acquire(indigo_core_gentable_t *gentable, of_object_t *key)
 void
 indigo_core_gentable_release(indigo_core_gentable_t *gentable, of_object_t *key);
 
+/*
+ * @brief Get the table ID of a gentable
+ * @param gentable
+ *
+ * Returns the table ID assigned to the given gentable.
+ */
+
+uint16_t
+indigo_core_gentable_id(indigo_core_gentable_t *gentable);
+
 
 /**
  * Listener interfaces


### PR DESCRIPTION
Reviewer: @harshsin

The table ID is used on the wire when referring to one table from another,
such as with of_action_bsn_gentable. The code parsing this action needs to
know what table ID was assigned when a gentable was registered.
