### PR TITLE
OFConnectionManager: fix issue with wrapping generation IDs

### DIFF
--- a/modules/OFConnectionManager/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager/module/src/cxn_instance.c
@@ -111,6 +111,7 @@ cleanup_disconnect(connection_t *cxn)
 
     /* Increment the generation ID for this connection */
     cxn->cxn_id += (1 << CXN_ID_GENERATION_SHIFT);
+    cxn->cxn_id &= 0x7fffffff; /* force non-negative */
     cxn->controller->aux_id_to_cxn_id[cxn->auxiliary_id] = cxn->cxn_id;
 
     /* @fixme Is it possible there's a message that should be processed? */


### PR DESCRIPTION
Reviewer: @kenchiang

The connection ID is actually a signed 32-bit integer. When over 32K
connection attempts occur, the generation ID would roll over into the most
significant bit, making the number negative. The CXN_ID_VALID macro would then
reject this connection ID.