### PR TITLE
OFConnectionManager: add asserts to silence static analysis warning

### DIFF
--- a/modules/OFConnectionManager/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager.c
@@ -1159,6 +1159,7 @@ ind_controller_accepts_async_message(const controller_t *ctrl,
        channel is not ready for communication, then we should just try
        to send on the main controller connection */
     *cxn = CXN_ID_TO_CONNECTION(ctrl->aux_id_to_cxn_id[auxiliary_id]);
+    AIM_ASSERT(*cxn != NULL);
     if (ind_cxn_accepts_async_message(*cxn) == 0) {
         if (auxiliary_id != 0) {
             AIM_LOG_TRACE("cxn: " CXN_FMT " state: %s, not ready, try on main cxn",
@@ -1166,6 +1167,7 @@ ind_controller_accepts_async_message(const controller_t *ctrl,
                           CXN_STATE_NAME(CONNECTION_STATE(*cxn)));
             auxiliary_id = 0;
             *cxn = CXN_ID_TO_CONNECTION(ctrl->aux_id_to_cxn_id[auxiliary_id]);
+            AIM_ASSERT(*cxn != NULL);
             if (ind_cxn_accepts_async_message(*cxn) == 0) {
                 return 0;
             }


### PR DESCRIPTION
Reviewer: trivial

The cxn_id_to_connection function can usually return null, which would lead to
a null dereference in ind_cxn_accepts_async_message. However, we maintain the
aux_id_to_cxn_id map so that none of the connection IDs are ever stale, so
*cxn will never be NULL.

I don't think this needs to be ported to OFConnectionManager2 since it stores
pointers in aux_id_to_cxn.