### PR TITLE
OFConnectionManager: commit bundle in a long running task

### DIFF
--- a/modules/OFConnectionManager/module/src/bundle.c
+++ b/modules/OFConnectionManager/module/src/bundle.c
@@ -307,10 +307,9 @@ bundle_task(void *cookie)
     connection_t *cxn = ind_cxn_id_to_connection(state->cxn_id);
 
     while (state->offset < state->count) {
-        of_object_storage_t obj_storage;
-        of_object_t *obj = parse_message(state->msgs[state->offset], &obj_storage);
-
         if (cxn) {
+            of_object_storage_t obj_storage;
+            of_object_t *obj = parse_message(state->msgs[state->offset], &obj_storage);
             ind_cxn_process_message(cxn, obj);
         } else {
             /* Connection went away. Drop remaining messages. */

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager.c
@@ -143,6 +143,12 @@ cxn_id_to_connection(indigo_cxn_id_t cxn_id)
     return cxn;
 }
 
+connection_t *
+ind_cxn_id_to_connection(indigo_cxn_id_t cxn_id)
+{
+    return cxn_id_to_connection(cxn_id);
+}
+
 /****************************************************************
  * Controller instance bookkeeping
  ****************************************************************/

--- a/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
+++ b/modules/OFConnectionManager/module/src/ofconnectionmanager_int.h
@@ -102,6 +102,8 @@ void ind_controller_disconnect(controller_t *ctrl);
 
 void ind_cxn_status_notify(void);
 
+connection_t *ind_cxn_id_to_connection(indigo_cxn_id_t cxn_id);
+
 /**
  * The OF message callback vector from state manager
  */


### PR DESCRIPTION
Reviewer: @kenchiang

To avoid blocking the rest of the event loop, these changes split the bundle 
commit into 10ms timeslices.