### PR TITLE
OFStateManager: assert that buckets_size is > 1

### DIFF
--- a/modules/OFStateManager/module/src/gentable_handlers.c
+++ b/modules/OFStateManager/module/src/gentable_handlers.c
@@ -113,6 +113,7 @@ indigo_core_gentable_register(
     AIM_TRUE_OR_DIE(ops->modify != NULL || ops->modify2 != NULL);
     AIM_TRUE_OR_DIE(ops->del != NULL || ops->del2 != NULL);
     AIM_TRUE_OR_DIE(ops->get_stats != NULL);
+    AIM_TRUE_OR_DIE(buckets_size > 1);
 
     struct indigo_core_gentable *gentable = aim_zmalloc(sizeof(*gentable));
 


### PR DESCRIPTION
Reviewer: trivial

When buckets_size == 1 we run into an integer overflow when iterating over the 
checksum buckets.