### PR TITLE
OFConnectionManager: turn paused field into a refcount

### DIFF
--- a/modules/OFConnectionManager/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager/module/src/cxn_instance.c
@@ -1642,7 +1642,7 @@ ind_cxn_disconnected_init(connection_t *cxn)
     cxn->status.messages_out = 0;
     cxn->fail_count = 0;
     cxn->hello_time = 0;
-    cxn->paused = false;
+    cxn->paused = 0;
 }
 
 /**
@@ -1742,18 +1742,19 @@ ind_cxn_unregister_debug_counters(connection_t *cxn)
 void
 ind_cxn_pause(connection_t *cxn)
 {
-    AIM_ASSERT(!cxn->paused);
-    if (ind_soc_data_in_pause(cxn->sd) < 0) {
-        LOG_INTERNAL(cxn, "Error pausing connection");
-        return;
+    if (cxn->paused++ == 0) {
+        if (ind_soc_data_in_pause(cxn->sd) < 0) {
+            LOG_INTERNAL(cxn, "Error pausing connection");
+            return;
+        }
     }
-    cxn->paused = true;
 }
 
 void
 ind_cxn_resume(connection_t *cxn)
 {
-    AIM_ASSERT(cxn->paused);
-    (void)ind_soc_data_in_resume(cxn->sd);
-    cxn->paused = false;
+    AIM_ASSERT(cxn->paused > 0);
+    if (--cxn->paused == 0) {
+        (void)ind_soc_data_in_resume(cxn->sd);
+    }
 }

--- a/modules/OFConnectionManager/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager/module/src/cxn_instance.c
@@ -1117,7 +1117,7 @@ read_message(connection_t *cxn)
     int rv = INDIGO_ERROR_NONE;
 
     /* Break out of message processing loop after a barrier */
-    if (cxn->paused) {
+    if (cxn->pause_refcount > 0) {
         return INDIGO_ERROR_PENDING;
     }
 
@@ -1642,7 +1642,7 @@ ind_cxn_disconnected_init(connection_t *cxn)
     cxn->status.messages_out = 0;
     cxn->fail_count = 0;
     cxn->hello_time = 0;
-    cxn->paused = 0;
+    cxn->pause_refcount = 0;
 }
 
 /**
@@ -1742,7 +1742,7 @@ ind_cxn_unregister_debug_counters(connection_t *cxn)
 void
 ind_cxn_pause(connection_t *cxn)
 {
-    if (cxn->paused++ == 0) {
+    if (cxn->pause_refcount++ == 0) {
         if (ind_soc_data_in_pause(cxn->sd) < 0) {
             LOG_INTERNAL(cxn, "Error pausing connection");
             return;
@@ -1753,8 +1753,8 @@ ind_cxn_pause(connection_t *cxn)
 void
 ind_cxn_resume(connection_t *cxn)
 {
-    AIM_ASSERT(cxn->paused > 0);
-    if (--cxn->paused == 0) {
+    AIM_ASSERT(cxn->pause_refcount > 0);
+    if (--cxn->pause_refcount == 0) {
         (void)ind_soc_data_in_resume(cxn->sd);
     }
 }

--- a/modules/OFConnectionManager/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager/module/src/cxn_instance.h
@@ -184,7 +184,7 @@ typedef struct connection_s {
 
     /* If nonzero, don't read any messages for this connection */
     /* Used as a refcount by bundles and barriers */
-    int paused;
+    int pause_refcount;
 } connection_t;
 
 /**

--- a/modules/OFConnectionManager/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager/module/src/cxn_instance.h
@@ -182,8 +182,9 @@ typedef struct connection_s {
     /* Pointer to the Controller clock to which this connection belongs */
     controller_t *controller;
 
-    /* If set, don't read any messages for this connection */
-    bool paused;
+    /* If nonzero, don't read any messages for this connection */
+    /* Used as a refcount by bundles and barriers */
+    int paused;
 } connection_t;
 
 /**


### PR DESCRIPTION
Reviewer: @kenchiang

The controller may send a barrier request inside a bundle. This would fail an 
assertion because the bundle already pauses the socket. The socket must remain 
paused until both the bundle and barrier are complete.