### PR TITLE
syslog the active controllers with valid main connections

### DIFF
--- a/modules/OFConnectionManager2/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.c
@@ -1527,13 +1527,14 @@ cxn_state_set(connection_t *cxn, cxn_state_t new_state)
         }
         break;
     case CXN_S_HANDSHAKE_COMPLETE:
+        cxn->status.is_connected = false;
         if (!CXN_LOCAL(cxn) && cxn->aux_id == 0) {
             AIM_SYSLOG_INFO("Disconnected from controller <ip-address>:<port>",
                             "The switch disconnected from the specified controller.",
                             "Disconnected from controller %s",
                             cxn->desc);
+            ind_cxn_syslog_active_controllers();
         }
-        cxn->status.is_connected = false;
         break;
     default:
         break;
@@ -1594,6 +1595,7 @@ cxn_state_set(connection_t *cxn, cxn_state_t new_state)
                             "The switch successfully connected to the specified controller.",
                             "Connected to controller %s",
                             cxn->desc);
+            ind_cxn_syslog_active_controllers();
         }
         break;
 

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -229,6 +229,35 @@ ind_cxn_send_cxn_list(void)
 
 
 /*
+ * To help debug controller-switch connection issues,
+ * syslog a space-separated list of connected controllers.
+ */
+void
+ind_cxn_syslog_active_controllers(void)
+{
+    int id;
+    controller_t *controller;
+    /* +1 for space between controller descriptions */
+    char buf[MAX_CONTROLLERS*(MAX_CONTROLLER_DESC_LEN+1)] = { 0 };
+    int count = 0;
+
+    FOREACH_REMOTE_ACTIVE_CONTROLLER(id, controller) {
+        connection_t *maincxn = controller->cxns[0];
+        if (maincxn && maincxn->status.is_connected) {
+            strcat(buf, " ");
+            strncat(buf, controller->desc, MAX_CONTROLLER_DESC_LEN);
+            count++;
+        }
+    }
+
+    AIM_SYSLOG_INFO("Connected controllers: <count>: <ip-address>:<port> ...",
+                    "Space-separated listing of connected controllers.",
+                    "Connected controllers: %d:%s", 
+                    count, count > 0? buf: " None");
+}
+
+
+/*
  * populate destbuf with useful connection identifying info.
  * destbuf has maximum length destbuflen.
  */

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager_int.h
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager_int.h
@@ -73,6 +73,8 @@ void controller_disconnect(controller_t *controller);
 
 void ind_cxn_notify_closed(connection_t *cxn);
 
+void ind_cxn_syslog_active_controllers(void);
+
 void ind_cxn_send_cxn_list(void);
 
 void ind_cxn_status_change(connection_t *cxn);


### PR DESCRIPTION
Reviewer: @rlane
Whenever the switch connects to or disconnects from a controller, generate a syslog message with a list of connected controllers.