### PR TITLE
OFConnectionManager2: sort barriers to the end of a bundle

### DIFF
--- a/modules/OFConnectionManager2/module/src/bundle.c
+++ b/modules/OFConnectionManager2/module/src/bundle.c
@@ -296,6 +296,11 @@ compare_message(const void *_a, const void *_b)
         return 0;
     }
 
+    if (obj_a->object_id == OF_BARRIER_REQUEST) {
+        /* Barriers go to the end of the bundle */
+        return 1;
+    }
+
     return comparator(obj_a, obj_b);
 }
 


### PR DESCRIPTION
Reviewer: @harshsin

If a bundle comparator is in use it could unintentionally reorder flow-mods 
around barrier messages. We expect at most one barrier request per bundle, so 
sort it to the end.