### PR TITLE
TLS config

### DIFF
--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager_int.h
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager_int.h
@@ -82,7 +82,13 @@ void ind_cxn_send_cxn_list(void);
 
 void ind_cxn_status_change(connection_t *cxn);
 
-extern void ind_cxn_stats_show(aim_pvs_t* pvs, int details);
+indigo_error_t
+ind_cxn_verify_tls(char *cipher_list,
+                   char *ca_cert,
+                   char *switch_cert,
+                   char *switch_priv_key);
+
+void ind_cxn_stats_show(aim_pvs_t* pvs, int details);
 
 /**
  * @brief Update the configuration of the connection manager

--- a/modules/indigo/module/inc/indigo/of_connection_manager.h
+++ b/modules/indigo/module/inc/indigo/of_connection_manager.h
@@ -312,6 +312,7 @@ typedef struct indigo_cxn_status_s {
  * @param cipher_list One or more cipher strings separated by colons.
  * See https://www.openssl.org/docs/manmaster/apps/ciphers.html for examples.
  * @param ca_cert Path to certificate authority's PEM-formatted certificate.
+ * Set to NULL to allow self-signed certificates.
  * @param switch_cert Path to switch's PEM-formatted certificate.
  * @param switch_priv_key Path to switch's PEM-formatted private key.
  */


### PR DESCRIPTION
Reviewer: @rlane 

Rework TLS config to verify first before saving config params.
Add config file parsing.
If no CA cert is set, allow self-signed certificates.