### PR TITLE
TLS: cert subject commonName suffix verification

### DIFF
--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -407,8 +407,11 @@ verify_cert(SSL_CTX *ctx, const char *cert_filename)
 static bool
 ends_with(char *str, char *searchstr)
 {
-    char *substr = strstr(str, searchstr);
-    return substr && (*(substr + strlen(searchstr)) == '\0');
+    int slen = strlen(str);
+    int searchlen = strlen(searchstr);
+
+    return (slen >= searchlen)?
+        (strcmp(str+slen-searchlen, searchstr) == 0): false;
 }
 
 static int
@@ -419,7 +422,7 @@ verify_cb(int preverify_ok, X509_STORE_CTX *ctx)
     /* skip all certificates except for server certificate at depth 0 */
     if (depth != 0) {
         AIM_LOG_VERBOSE("Depth %d: preverify_ok %d", depth, preverify_ok);
-        return preverify_ok? 1: 0;
+        return preverify_ok;
     }
 
     /* get common name entry from certificate's subject name */

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -586,7 +586,7 @@ indigo_cxn_config_tls(char *cipher_list,
                                     sizeof(tls_cfg.switch_cert));
         OFCONNECTIONMANAGER_STRNCPY(tls_cfg.switch_priv_key, switch_priv_key,
                                     sizeof(tls_cfg.switch_priv_key));
-        if (exp_controller_suffix) {
+        if (exp_controller_suffix && (exp_controller_suffix[0] != '\0')) {
             tls_cfg.check_controller_suffix = true;
             OFCONNECTIONMANAGER_STRNCPY(tls_cfg.exp_controller_suffix,
                                         exp_controller_suffix,
@@ -611,6 +611,9 @@ ind_cxn_tls_config_show(aim_pvs_t *pvs)
                tls_cfg.ca_cert[0] != '\0'?  tls_cfg.ca_cert: "None");
     aim_printf(pvs, "switch_cert: %s\n", tls_cfg.switch_cert);
     aim_printf(pvs, "switch_priv_key: %s\n", tls_cfg.switch_priv_key);
+    aim_printf(pvs, "exp_controller_suffix: %s\n",
+               tls_cfg.check_controller_suffix?
+               tls_cfg.exp_controller_suffix: "None");
 }
 
 

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager_int.h
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager_int.h
@@ -86,7 +86,8 @@ indigo_error_t
 ind_cxn_verify_tls(char *cipher_list,
                    char *ca_cert,
                    char *switch_cert,
-                   char *switch_priv_key);
+                   char *switch_priv_key,
+                   char *exp_controller_suffix);
 
 void ind_cxn_stats_show(aim_pvs_t* pvs, int details);
 

--- a/modules/indigo/module/inc/indigo/of_connection_manager.h
+++ b/modules/indigo/module/inc/indigo/of_connection_manager.h
@@ -315,12 +315,15 @@ typedef struct indigo_cxn_status_s {
  * Set to NULL to allow self-signed certificates.
  * @param switch_cert Path to switch's PEM-formatted certificate.
  * @param switch_priv_key Path to switch's PEM-formatted private key.
+ * @param exp_controller_suffix If not NULL and ca_cert is not NULL,
+ * will verify that the controller's commonName ends with this string.
  */
 extern indigo_error_t
 indigo_cxn_config_tls(char *cipher_list,
                       char *ca_cert,
                       char *switch_cert,
-                      char *switch_priv_key);
+                      char *switch_priv_key,
+                      char *exp_controller_suffix);
 #endif /* DEPENDMODULE_INCLUDE_OFCONNECTIONMANAGER2 */
 
 /**


### PR DESCRIPTION
Reviewer: @rlane 

Allow an expected controller suffix to be configured and verify that the controller's subject commonName contains that controller suffix.
