### PR TITLE
indigo cleanup: Use aim_free for aim_malloced memory.

### DIFF
--- a/modules/Configuration/module/src/configuration.c
+++ b/modules/Configuration/module/src/configuration.c
@@ -34,13 +34,13 @@ indigo_error_t
 ind_cfg_filename_set(char *filename)
 {
     char *tmp_name;
-    if ((tmp_name = strdup(filename)) == NULL) {
+    if ((tmp_name = aim_strdup(filename)) == NULL) {
         AIM_LOG_ERROR("Config:  Failed to set filename str to %s", filename);
         return INDIGO_ERROR_RESOURCE;
     }
 
     if (current_filename != NULL) {
-        free(current_filename);
+        aim_free(current_filename);
     }
     current_filename = tmp_name;
 
@@ -135,7 +135,7 @@ parse_json_file(const char *filename)
     fseek(f, 0, SEEK_SET);
     data = aim_malloc(len + 1);
     if (fread(data, 1, len, f) == 0) {
-        free(data);
+        aim_free(data);
         fclose(f);
         AIM_LOG_ERROR("failed to read %s", filename);
         return NULL;
@@ -158,11 +158,11 @@ parse_json_file(const char *filename)
 
         AIM_LOG_ERROR("Error at line %d col %d: [%.8s]\n", line, col, errptr);
 
-        free(data);
+        aim_free(data);
         return NULL;
     }
 
-    free(data);
+    aim_free(data);
 
     return root;
 }
@@ -266,7 +266,7 @@ indigo_error_t
 ind_cfg_lookup(cJSON *root, const char *path_, cJSON **result)
 {
     /* strtok_r mutates its input, need to copy */
-    char *path = strdup(path_);
+    char *path = aim_strdup(path_);
     char *saveptr = NULL;
     char *token;
     cJSON *node = root;
@@ -281,7 +281,7 @@ ind_cfg_lookup(cJSON *root, const char *path_, cJSON **result)
         }
     }
 
-    free(path);
+    aim_free(path);
     *result = err == INDIGO_ERROR_NONE ? node : NULL;
     return err;
 }

--- a/modules/OFConnectionManager2/module/src/bundle.c
+++ b/modules/OFConnectionManager2/module/src/bundle.c
@@ -261,10 +261,10 @@ free_bundle(bundle_t *bundle)
 {
     int i;
     for (i = 0; i < bundle->count; i++) {
-        free(bundle->msgs[i]);
+        aim_free(bundle->msgs[i]);
     }
 
-    free(bundle->msgs);
+    aim_free(bundle->msgs);
 
     bundle->id = BUNDLE_ID_INVALID;
     bundle->msgs = NULL;
@@ -320,7 +320,7 @@ bundle_task(void *cookie)
             /* Connection went away. Drop remaining messages. */
         }
 
-        free(state->msgs[state->offset]);
+        aim_free(state->msgs[state->offset]);
         state->msgs[state->offset] = NULL;
         state->offset++;
 
@@ -329,8 +329,8 @@ bundle_task(void *cookie)
         }
     }
 
-    free(state->msgs);
-    free(state);
+    aim_free(state->msgs);
+    aim_free(state);
 
     if (cxn) {
         ind_cxn_resume(cxn);

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -279,32 +279,32 @@ ind_cxn_proto_ip_string(indigo_cxn_protocol_params_t *params,
 
     switch (params->header.protocol) {
     case INDIGO_CXN_PROTO_TCP_OVER_IPV4:
-        len = snprintf(destbuf, destbuflen, "tcp:%s:%d",
-                       params->tcp_over_ipv4.controller_ip,
-                       params->tcp_over_ipv4.controller_port);
+        len = OFCONNECTIONMANAGER_SNPRINTF(destbuf, destbuflen, "tcp:%s:%d",
+                                           params->tcp_over_ipv4.controller_ip,
+                                           params->tcp_over_ipv4.controller_port);
         break;
     case INDIGO_CXN_PROTO_TLS_OVER_IPV4:
-        len = snprintf(destbuf, destbuflen, "tls:%s:%d",
-                       params->tcp_over_ipv4.controller_ip,
-                       params->tcp_over_ipv4.controller_port);
+        len = OFCONNECTIONMANAGER_SNPRINTF(destbuf, destbuflen, "tls:%s:%d",
+                                           params->tcp_over_ipv4.controller_ip,
+                                           params->tcp_over_ipv4.controller_port);
         break;
     case INDIGO_CXN_PROTO_TCP_OVER_IPV6:
-        len = snprintf(destbuf, destbuflen, "tcp6:%s:%d",
-                       params->tcp_over_ipv6.controller_ip,
-                       params->tcp_over_ipv6.controller_port);
+        len = OFCONNECTIONMANAGER_SNPRINTF(destbuf, destbuflen, "tcp6:%s:%d",
+                                           params->tcp_over_ipv6.controller_ip,
+                                           params->tcp_over_ipv6.controller_port);
         break;
     case INDIGO_CXN_PROTO_TLS_OVER_IPV6:
-        len = snprintf(destbuf, destbuflen, "tls6:%s:%d",
-                       params->tcp_over_ipv6.controller_ip,
-                       params->tcp_over_ipv6.controller_port);
+        len = OFCONNECTIONMANAGER_SNPRINTF(destbuf, destbuflen, "tls6:%s:%d",
+                                           params->tcp_over_ipv6.controller_ip,
+                                           params->tcp_over_ipv6.controller_port);
         break;
     case INDIGO_CXN_PROTO_UNIX:
-        len = snprintf(destbuf, destbuflen, "%s",
-                       params->unx.unix_path);
+        len = OFCONNECTIONMANAGER_SNPRINTF(destbuf, destbuflen, "%s",
+                                           params->unx.unix_path);
         break;
     case INDIGO_CXN_PROTO_INVALID:  /* fall-through */
     default:
-        strcpy(destbuf, inv);
+        OFCONNECTIONMANAGER_STRNCPY(destbuf, inv, sizeof(inv));
         len = sizeof(inv)-1;
         break;
     }
@@ -2150,7 +2150,7 @@ parse_sockaddr_getaddrinfo(int family, const char *addr, int port,
                            socklen_t *sockaddrlen)
 {
     char port_str[8];
-    snprintf(port_str, sizeof(port_str), "%u", port);
+    OFCONNECTIONMANAGER_SNPRINTF(port_str, sizeof(port_str), "%u", port);
 
     struct addrinfo hints;
     memset(&hints, 0, sizeof(hints));
@@ -2170,7 +2170,7 @@ parse_sockaddr_getaddrinfo(int family, const char *addr, int port,
         return INDIGO_ERROR_PARAM;
     }
 
-    memcpy(sockaddr, ai->ai_addr, ai->ai_addrlen);
+    OFCONNECTIONMANAGER_MEMCPY(sockaddr, ai->ai_addr, ai->ai_addrlen);
     *sockaddrlen = ai->ai_addrlen;
     freeaddrinfo(ai);
     return INDIGO_ERROR_NONE;
@@ -2183,7 +2183,8 @@ parse_sockaddr_unix(const char *path,
 {
     struct sockaddr_un *sun = (struct sockaddr_un *) sockaddr;
     sun->sun_family = AF_UNIX;
-    snprintf(sun->sun_path, sizeof(sun->sun_path), "%s", path);
+    OFCONNECTIONMANAGER_SNPRINTF(sun->sun_path, sizeof(sun->sun_path),
+                                 "%s", path);
     *sockaddrlen = sizeof(*sun);
     return INDIGO_ERROR_NONE;
 }

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager_config.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager_config.c
@@ -272,19 +272,22 @@ parse_controller(struct controller *controller, cJSON *root)
     case INDIGO_CXN_PROTO_TLS_OVER_IPV4:
         params4 = &controller->proto.tcp_over_ipv4;
         params4->protocol = proto;
-        strncpy(params4->controller_ip, ip, sizeof(params4->controller_ip));
+        OFCONNECTIONMANAGER_STRNCPY(params4->controller_ip, ip,
+                                    sizeof(params4->controller_ip));
         params4->controller_port = port;
         break;
     case INDIGO_CXN_PROTO_TCP_OVER_IPV6:  /* fall-through */
     case INDIGO_CXN_PROTO_TLS_OVER_IPV6:
         params6 = &controller->proto.tcp_over_ipv6;
         params6->protocol = proto;
-        strncpy(params6->controller_ip, ip, sizeof(params6->controller_ip));
+        OFCONNECTIONMANAGER_STRNCPY(params6->controller_ip, ip,
+                                    sizeof(params6->controller_ip));
         params6->controller_port = port;
         break;
     case INDIGO_CXN_PROTO_UNIX:
         params_unix = &controller->proto.unx;
-        strncpy(params_unix->unix_path, unix_path, INDIGO_CXN_UNIX_PATH_LEN);
+        OFCONNECTIONMANAGER_STRNCPY(params_unix->unix_path, unix_path,
+                                    INDIGO_CXN_UNIX_PATH_LEN);
         break;
     default:
         AIM_DIE("Config: No handling for protocol %d", proto);


### PR DESCRIPTION
Reviewer: @rlane 
Also use porting macros.

When used with a memory tracker built on aim_malloc and aim_free, the aim_free changes will reduce the number of cases where memory is apparently leaked but really is not.
