### PR TITLE
Use aim_free for aim_malloced memory.

### DIFF
--- a/modules/Configuration/module/src/configuration.c
+++ b/modules/Configuration/module/src/configuration.c
@@ -34,13 +34,13 @@ indigo_error_t
 ind_cfg_filename_set(char *filename)
 {
     char *tmp_name;
-    if ((tmp_name = strdup(filename)) == NULL) {
+    if ((tmp_name = aim_strdup(filename)) == NULL) {
         AIM_LOG_ERROR("Config:  Failed to set filename str to %s", filename);
         return INDIGO_ERROR_RESOURCE;
     }
 
     if (current_filename != NULL) {
-        free(current_filename);
+        aim_free(current_filename);
     }
     current_filename = tmp_name;
 
@@ -135,7 +135,7 @@ parse_json_file(const char *filename)
     fseek(f, 0, SEEK_SET);
     data = aim_malloc(len + 1);
     if (fread(data, 1, len, f) == 0) {
-        free(data);
+        aim_free(data);
         fclose(f);
         AIM_LOG_ERROR("failed to read %s", filename);
         return NULL;
@@ -158,11 +158,11 @@ parse_json_file(const char *filename)
 
         AIM_LOG_ERROR("Error at line %d col %d: [%.8s]\n", line, col, errptr);
 
-        free(data);
+        aim_free(data);
         return NULL;
     }
 
-    free(data);
+    aim_free(data);
 
     return root;
 }
@@ -266,7 +266,7 @@ indigo_error_t
 ind_cfg_lookup(cJSON *root, const char *path_, cJSON **result)
 {
     /* strtok_r mutates its input, need to copy */
-    char *path = strdup(path_);
+    char *path = aim_strdup(path_);
     char *saveptr = NULL;
     char *token;
     cJSON *node = root;
@@ -281,7 +281,7 @@ ind_cfg_lookup(cJSON *root, const char *path_, cJSON **result)
         }
     }
 
-    free(path);
+    aim_free(path);
     *result = err == INDIGO_ERROR_NONE ? node : NULL;
     return err;
 }

--- a/modules/OFConnectionManager2/module/src/bundle.c
+++ b/modules/OFConnectionManager2/module/src/bundle.c
@@ -261,10 +261,10 @@ free_bundle(bundle_t *bundle)
 {
     int i;
     for (i = 0; i < bundle->count; i++) {
-        free(bundle->msgs[i]);
+        aim_free(bundle->msgs[i]);
     }
 
-    free(bundle->msgs);
+    aim_free(bundle->msgs);
 
     bundle->id = BUNDLE_ID_INVALID;
     bundle->msgs = NULL;
@@ -320,7 +320,7 @@ bundle_task(void *cookie)
             /* Connection went away. Drop remaining messages. */
         }
 
-        free(state->msgs[state->offset]);
+        aim_free(state->msgs[state->offset]);
         state->msgs[state->offset] = NULL;
         state->offset++;
 
@@ -329,8 +329,8 @@ bundle_task(void *cookie)
         }
     }
 
-    free(state->msgs);
-    free(state);
+    aim_free(state->msgs);
+    aim_free(state);
 
     if (cxn) {
         ind_cxn_resume(cxn);

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -576,28 +576,23 @@ indigo_cxn_config_tls(char *cipher_list,
                             switch_cert, switch_priv_key,
                             exp_controller_suffix);
     if (rv == INDIGO_ERROR_NONE) {
-        OFCONNECTIONMANAGER_STRNCPY(tls_cfg.cipher_list, cipher_list,
-                                    sizeof(tls_cfg.cipher_list));
+        strncpy(tls_cfg.cipher_list, cipher_list, sizeof(tls_cfg.cipher_list));
         if (ca_cert) {
-            OFCONNECTIONMANAGER_STRNCPY(tls_cfg.ca_cert, ca_cert,
-                                        sizeof(tls_cfg.ca_cert));
+            strncpy(tls_cfg.ca_cert, ca_cert, sizeof(tls_cfg.ca_cert));
         } else {
-            OFCONNECTIONMANAGER_MEMSET(tls_cfg.ca_cert, 0,
-                                        sizeof(tls_cfg.ca_cert));
+            memset(tls_cfg.ca_cert, 0, sizeof(tls_cfg.ca_cert));
         }
-        OFCONNECTIONMANAGER_STRNCPY(tls_cfg.switch_cert, switch_cert,
-                                    sizeof(tls_cfg.switch_cert));
-        OFCONNECTIONMANAGER_STRNCPY(tls_cfg.switch_priv_key, switch_priv_key,
-                                    sizeof(tls_cfg.switch_priv_key));
+        strncpy(tls_cfg.switch_cert, switch_cert, sizeof(tls_cfg.switch_cert));
+        strncpy(tls_cfg.switch_priv_key, switch_priv_key,
+                sizeof(tls_cfg.switch_priv_key));
         if (exp_controller_suffix && (exp_controller_suffix[0] != '\0')) {
             tls_cfg.check_controller_suffix = true;
-            OFCONNECTIONMANAGER_STRNCPY(tls_cfg.exp_controller_suffix,
-                                        exp_controller_suffix,
-                                        sizeof(tls_cfg.exp_controller_suffix));
+            strncpy(tls_cfg.exp_controller_suffix, exp_controller_suffix,
+                    sizeof(tls_cfg.exp_controller_suffix));
         } else {
             tls_cfg.check_controller_suffix = false;
-            OFCONNECTIONMANAGER_MEMSET(tls_cfg.exp_controller_suffix, 0,
-                                       sizeof(tls_cfg.exp_controller_suffix));
+            memset(tls_cfg.exp_controller_suffix, 0,
+                   sizeof(tls_cfg.exp_controller_suffix));
         }
     }
 

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager_config.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager_config.c
@@ -469,26 +469,21 @@ parse_tls_config(cJSON *root)
         goto error;
     }
 
-    OFCONNECTIONMANAGER_STRNCPY(staged_config.cipher_list, cipher_list,
-                                INDIGO_TLS_CFG_PARAM_LEN);
+    strncpy(staged_config.cipher_list, cipher_list, INDIGO_TLS_CFG_PARAM_LEN);
     if (ca_cert) {
-        OFCONNECTIONMANAGER_STRNCPY(staged_config.ca_cert, ca_cert,
-                                    INDIGO_TLS_CFG_PARAM_LEN);
+        strncpy(staged_config.ca_cert, ca_cert, INDIGO_TLS_CFG_PARAM_LEN);
     } else {
-        OFCONNECTIONMANAGER_MEMSET(staged_config.ca_cert, 0,
-                                   INDIGO_TLS_CFG_PARAM_LEN);
+        memset(staged_config.ca_cert, 0, INDIGO_TLS_CFG_PARAM_LEN);
     }
-    OFCONNECTIONMANAGER_STRNCPY(staged_config.switch_cert, switch_cert,
-                                INDIGO_TLS_CFG_PARAM_LEN);
-    OFCONNECTIONMANAGER_STRNCPY(staged_config.switch_priv_key, switch_priv_key,
-                                INDIGO_TLS_CFG_PARAM_LEN);
+    strncpy(staged_config.switch_cert, switch_cert, INDIGO_TLS_CFG_PARAM_LEN);
+    strncpy(staged_config.switch_priv_key, switch_priv_key,
+            INDIGO_TLS_CFG_PARAM_LEN);
     if (exp_controller_suffix) {
-        OFCONNECTIONMANAGER_STRNCPY(staged_config.exp_controller_suffix,
-                                    exp_controller_suffix,
-                                    INDIGO_TLS_CFG_PARAM_LEN);
+        strncpy(staged_config.exp_controller_suffix, exp_controller_suffix,
+                INDIGO_TLS_CFG_PARAM_LEN);
     } else {
-        OFCONNECTIONMANAGER_MEMSET(staged_config.exp_controller_suffix, 0,
-                                   INDIGO_TLS_CFG_PARAM_LEN);
+        memset(staged_config.exp_controller_suffix, 0,
+               INDIGO_TLS_CFG_PARAM_LEN);
     }
 
     AIM_LOG_INFO("Config: TLS mode %s, cipher list %s, ca_cert %s, "
@@ -501,16 +496,11 @@ parse_tls_config(cJSON *root)
 
  error:
     AIM_LOG_VERBOSE("Config: Clearing TLS params");
-    OFCONNECTIONMANAGER_MEMSET(staged_config.cipher_list, 0,
-                               INDIGO_TLS_CFG_PARAM_LEN);
-    OFCONNECTIONMANAGER_MEMSET(staged_config.ca_cert, 0,
-                               INDIGO_TLS_CFG_PARAM_LEN);
-    OFCONNECTIONMANAGER_MEMSET(staged_config.switch_cert, 0,
-                               INDIGO_TLS_CFG_PARAM_LEN);
-    OFCONNECTIONMANAGER_MEMSET(staged_config.switch_priv_key, 0,
-                               INDIGO_TLS_CFG_PARAM_LEN);
-    OFCONNECTIONMANAGER_MEMSET(staged_config.exp_controller_suffix, 0,
-                               INDIGO_TLS_CFG_PARAM_LEN);
+    memset(staged_config.cipher_list, 0, INDIGO_TLS_CFG_PARAM_LEN);
+    memset(staged_config.ca_cert, 0, INDIGO_TLS_CFG_PARAM_LEN);
+    memset(staged_config.switch_cert, 0, INDIGO_TLS_CFG_PARAM_LEN);
+    memset(staged_config.switch_priv_key, 0, INDIGO_TLS_CFG_PARAM_LEN);
+    memset(staged_config.exp_controller_suffix, 0, INDIGO_TLS_CFG_PARAM_LEN);
     return err;
 }
 


### PR DESCRIPTION
Reviewer: @rlane 
Convert porting macros.