### PR TITLE
Gentable errors send of_bsn_error messages instead of BAD_REQUEST/EPERM.

### DIFF
--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -1895,11 +1895,12 @@ indigo_cxn_send_error_reply(indigo_cxn_id_t cxn_id, of_object_t *orig,
 
 void
 indigo_cxn_send_bsn_error(indigo_cxn_id_t cxn_id, of_object_t *orig,
-                          of_desc_str_t err_txt)
+                          char *err_txt)
 {
     of_bsn_error_t *err;
     of_octets_t payload;
     uint32_t xid;
+    of_desc_str_t dst_txt = "";
 
     connection_t *cxn = ind_cxn_id_to_connection(cxn_id);
     if (cxn == NULL) {
@@ -1921,7 +1922,8 @@ indigo_cxn_send_bsn_error(indigo_cxn_id_t cxn_id, of_object_t *orig,
     }
 
     of_bsn_error_xid_set(err, xid);
-    of_bsn_error_err_msg_set(err, err_txt);
+    strncpy(dst_txt, err_txt, sizeof(dst_txt));
+    of_bsn_error_err_msg_set(err, dst_txt);
 
     if (of_bsn_error_data_set(err, &payload) < 0) {
         AIM_LOG_INTERNAL("Failed to append original request to error message");

--- a/modules/OFStateManager/module/src/gentable_handlers.c
+++ b/modules/OFStateManager/module/src/gentable_handlers.c
@@ -269,11 +269,10 @@ ind_core_bsn_gentable_entry_add_handler(
     return;
 
 error:
-    /* Not a great error code but we don't have many options */
-    indigo_cxn_send_error_reply(
-        cxn_id, obj,
-        OF_ERROR_TYPE_BAD_REQUEST,
-        OF_REQUEST_FAILED_EPERM);
+    {
+        of_desc_str_t err_txt = "Gentable add failed";
+        indigo_cxn_send_bsn_error(cxn_id, obj, err_txt);
+    }
 }
 
 void
@@ -308,12 +307,10 @@ ind_core_bsn_gentable_entry_delete_handler(
 
     rv = delete_entry(cxn_id, gentable, entry);
     if (rv < 0) {
+        of_desc_str_t err_txt = "Gentable delete failed";
         AIM_LOG_ERROR("%s gentable delete failed: %s",
                       gentable->name, indigo_strerror(rv));
-        indigo_cxn_send_error_reply(
-            cxn_id, obj,
-            OF_ERROR_TYPE_BAD_REQUEST,
-            OF_REQUEST_FAILED_EPERM);
+        indigo_cxn_send_bsn_error(cxn_id, obj, err_txt);
         return;
     }
 }
@@ -419,12 +416,10 @@ ind_core_bsn_gentable_set_buckets_size_handler(
     }
 
     if (new_buckets_size == 0 || (new_buckets_size & (new_buckets_size - 1)) != 0) {
+        of_desc_str_t err_txt = "Gentable set bucket size failed";
         AIM_LOG_ERROR("Attempted to set a non power of 2 buckets size (%d) for gentable %s",
                       new_buckets_size, gentable->name);
-        indigo_cxn_send_error_reply(
-            cxn_id, obj,
-            OF_ERROR_TYPE_BAD_REQUEST,
-            OF_REQUEST_FAILED_EPERM);
+        indigo_cxn_send_bsn_error(cxn_id, obj, err_txt);
         return;
     }
 

--- a/modules/OFStateManager/module/src/gentable_handlers.c
+++ b/modules/OFStateManager/module/src/gentable_handlers.c
@@ -269,10 +269,7 @@ ind_core_bsn_gentable_entry_add_handler(
     return;
 
 error:
-    {
-        of_desc_str_t err_txt = "Gentable add failed";
-        indigo_cxn_send_bsn_error(cxn_id, obj, err_txt);
-    }
+    indigo_cxn_send_bsn_error(cxn_id, obj, "Gentable add failed");
 }
 
 void
@@ -307,10 +304,9 @@ ind_core_bsn_gentable_entry_delete_handler(
 
     rv = delete_entry(cxn_id, gentable, entry);
     if (rv < 0) {
-        of_desc_str_t err_txt = "Gentable delete failed";
         AIM_LOG_ERROR("%s gentable delete failed: %s",
                       gentable->name, indigo_strerror(rv));
-        indigo_cxn_send_bsn_error(cxn_id, obj, err_txt);
+        indigo_cxn_send_bsn_error(cxn_id, obj, "Gentable delete failed");
         return;
     }
 }
@@ -416,10 +412,10 @@ ind_core_bsn_gentable_set_buckets_size_handler(
     }
 
     if (new_buckets_size == 0 || (new_buckets_size & (new_buckets_size - 1)) != 0) {
-        of_desc_str_t err_txt = "Gentable set bucket size failed";
         AIM_LOG_ERROR("Attempted to set a non power of 2 buckets size (%d) for gentable %s",
                       new_buckets_size, gentable->name);
-        indigo_cxn_send_bsn_error(cxn_id, obj, err_txt);
+        indigo_cxn_send_bsn_error(cxn_id, obj,
+                                  "Gentable set bucket size failed");
         return;
     }
 

--- a/modules/OFStateManager/utest/main.c
+++ b/modules/OFStateManager/utest/main.c
@@ -196,6 +196,14 @@ indigo_cxn_send_error_reply(indigo_cxn_id_t cxn_id, of_object_t *orig,
                       cxn_id);
 }
 
+void
+indigo_cxn_send_bsn_error(indigo_cxn_id_t cxn_id, of_object_t *orig,
+                          char *err_txt)
+{
+    AIM_LOG_VERBOSE("Send BSN error msg called for cxn id %d: %s\n",
+                    cxn_id, err_txt);
+}
+
 static int controller_message_counters[OF_MESSAGE_OBJECT_COUNT];
 
 void

--- a/modules/indigo/module/inc/indigo/of_connection_manager.h
+++ b/modules/indigo/module/inc/indigo/of_connection_manager.h
@@ -475,6 +475,17 @@ extern void
 indigo_cxn_send_error_reply(indigo_cxn_id_t cxn_id, of_object_t *orig,
                             uint16_t type, uint16_t code);
 
+/**
+ * Send a BSN error message to a controller connection
+ * @param cxn_id Controller to receive msg
+ * @param orig Message this error is in response to
+ * @param err_txt Informative text to be copied into error msg
+ */
+
+void
+indigo_cxn_send_bsn_error(indigo_cxn_id_t cxn_id, of_object_t *orig,
+                          of_desc_str_t err_txt);
+
 
 /**
  * Connection information structure.

--- a/modules/indigo/module/inc/indigo/of_connection_manager.h
+++ b/modules/indigo/module/inc/indigo/of_connection_manager.h
@@ -484,7 +484,7 @@ indigo_cxn_send_error_reply(indigo_cxn_id_t cxn_id, of_object_t *orig,
 
 void
 indigo_cxn_send_bsn_error(indigo_cxn_id_t cxn_id, of_object_t *orig,
-                          of_desc_str_t err_txt);
+                          char *err_txt);
 
 
 /**


### PR DESCRIPTION
Reviewer: @rlane 

Depends on of_bsn_error https://github.com/floodlight/loxigen/pull/441.
