### PR TITLE
loci: add trailing slash to LOCI_SUBDIR

### DIFF
--- a/modules/loci/make.mk
+++ b/modules/loci/make.mk
@@ -33,5 +33,5 @@ loci_CFLAGS := -Os
 endif
 
 LIBRARY := loci
-loci_SUBDIR := $(LOCI)/src
+loci_SUBDIR := $(LOCI)/src/
 include $(BUILDER)/lib.mk


### PR DESCRIPTION
Reviewer: trivial

Normal SUBDIR variables have a trailing slash. Upcoming build system changes
will require it.