### PR TITLE
OFStateManager: add generic stats registration APIs

### DIFF
--- a/modules/OFStateManager/module/src/generic_stats_handlers.c
+++ b/modules/OFStateManager/module/src/generic_stats_handlers.c
@@ -1,0 +1,104 @@
+/****************************************************************
+ *
+ *        Copyright 2016, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+/**
+ * @file
+ * @brief OpenFlow message handlers for generic stats messages
+ *
+ * See detailed documentation in the Indigo architecture headers.
+ */
+
+#include "ofstatemanager_log.h"
+
+#include <OFStateManager/ofstatemanager_config.h>
+#include <indigo/indigo.h>
+#include <loci/loci.h>
+#include "ofstatemanager_decs.h"
+#include "ofstatemanager_int.h"
+#include "handlers.h"
+
+static LIST_DEFINE(generic_stats_head);
+
+struct generic_stats {
+    list_links_t links;
+    indigo_core_generic_stats_f handler;
+    void *priv;
+    of_str64_t name;
+};
+
+static struct generic_stats *find_generic_stats(const char *name);
+
+void
+indigo_core_generic_stats_register(
+    const char *name,
+    indigo_core_generic_stats_f handler,
+    void *priv)
+{
+    AIM_ASSERT(strlen(name) < sizeof(of_str64_t));
+    AIM_ASSERT(find_generic_stats(name) == NULL);
+    struct generic_stats *generic_stats = aim_zmalloc(sizeof(*generic_stats));
+    strncpy(generic_stats->name, name, sizeof(generic_stats->name));
+    generic_stats->handler = handler;
+    generic_stats->priv = priv;
+    list_push(&generic_stats_head, &generic_stats->links);
+}
+
+void
+indigo_core_generic_stats_unregister(const char *name)
+{
+    struct generic_stats *generic_stats = find_generic_stats(name);
+    if (generic_stats == NULL) {
+        return;
+    }
+
+    list_remove(&generic_stats->links);
+    aim_free(generic_stats);
+}
+
+void
+ind_core_bsn_generic_stats_request_handler(
+    of_object_t *req,
+    indigo_cxn_id_t cxn_id)
+{
+    of_str64_t name;
+    of_bsn_generic_stats_request_name_get(req, &name);
+
+    struct generic_stats *generic_stats = find_generic_stats(name);
+    if (generic_stats == NULL) {
+        char msg[128];
+        snprintf(msg, sizeof(msg), "Unknown generic stats request '%.64s'", name);
+        indigo_cxn_send_bsn_error(cxn_id, req, msg);
+        return;
+    }
+
+    generic_stats->handler(cxn_id, req, generic_stats->priv);
+}
+
+static struct generic_stats *
+find_generic_stats(const char *name)
+{
+    struct list_links *cur;
+    LIST_FOREACH(&generic_stats_head, cur) {
+        struct generic_stats *generic_stats = container_of(cur, links, struct generic_stats);
+        if (!strncmp(generic_stats->name, name, sizeof(of_str64_t))) {
+            return generic_stats;
+        }
+    }
+    return NULL;
+}

--- a/modules/OFStateManager/module/src/handlers.h
+++ b/modules/OFStateManager/module/src/handlers.h
@@ -190,4 +190,10 @@ ind_core_bsn_debug_counter_stats_request_handler(
     of_object_t *_obj,
     indigo_cxn_id_t cxn_id);
 
+/* generic_stats_handlers.c */
+void
+ind_core_bsn_generic_stats_request_handler(
+    of_object_t *_obj,
+    indigo_cxn_id_t cxn_id);
+
 #endif /* _OF_STATE_HANDLERS_H_ */

--- a/modules/OFStateManager/module/src/ofstatemanager.c
+++ b/modules/OFStateManager/module/src/ofstatemanager.c
@@ -421,6 +421,10 @@ indigo_core_receive_controller_message(indigo_cxn_id_t cxn, of_object_t *obj)
         ind_core_bsn_debug_counter_stats_request_handler(obj, cxn);
         break;
 
+    case OF_BSN_GENERIC_STATS_REQUEST:
+        ind_core_bsn_generic_stats_request_handler(obj, cxn);
+        break;
+
     /* These all use the experimenter handler */
     case OF_BSN_GET_MIRRORING_REQUEST:
     case OF_BSN_SET_MIRRORING:

--- a/modules/OFStateManager/utest/generic_stats_test.c
+++ b/modules/OFStateManager/utest/generic_stats_test.c
@@ -1,0 +1,92 @@
+/****************************************************************
+ *
+ *        Copyright 2016, Big Switch Networks, Inc.
+ *
+ * Licensed under the Eclipse Public License, Version 1.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *        http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific
+ * language governing permissions and limitations under the
+ * License.
+ *
+ ****************************************************************/
+
+#define AIM_LOG_MODULE_NAME ofstatemanager_utest
+#include <AIM/aim_log.h>
+
+#include <OFStateManager/ofstatemanager.h>
+#include <OFStateManager/ofstatemanager_config.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <loci/loci.h>
+#include <locitest/unittest.h>
+#include <locitest/test_common.h>
+#include <SocketManager/socketmanager.h>
+
+extern void handle_message(of_object_t *obj);
+extern int do_barrier(void);
+
+static int count1 = 0;
+static int count2 = 0;
+
+static void
+handler(indigo_cxn_id_t cxn_id,
+        const of_bsn_generic_stats_request_t *req,
+        void *priv)
+{
+    (*(int *)priv)++;
+}
+
+static void
+send_generic_stats_request(const char *name)
+{
+    of_object_t *req = of_bsn_generic_stats_request_new(OF_VERSION_1_4);
+    of_str64_t name_buf = "";
+    strncpy(name_buf, name, sizeof(name_buf));
+    of_bsn_generic_stats_request_name_set(req, name_buf);
+    handle_message(req);
+    do_barrier();
+}
+
+int
+test_generic_stats(void)
+{
+    send_generic_stats_request("stats1");
+    AIM_ASSERT(count1 == 0);
+    AIM_ASSERT(count2 == 0);
+
+    indigo_core_generic_stats_register("stats1", handler, &count1);
+    send_generic_stats_request("stats1");
+    send_generic_stats_request("stats2");
+    AIM_ASSERT(count1 == 1);
+    AIM_ASSERT(count2 == 0);
+
+    indigo_core_generic_stats_register("stats2", handler, &count2);
+    send_generic_stats_request("stats1");
+    send_generic_stats_request("stats2");
+    AIM_ASSERT(count1 == 2);
+    AIM_ASSERT(count2 == 1);
+
+    indigo_core_generic_stats_unregister("stats1");
+    send_generic_stats_request("stats1");
+    send_generic_stats_request("stats2");
+    AIM_ASSERT(count1 == 2);
+    AIM_ASSERT(count2 == 2);
+
+    indigo_core_generic_stats_unregister("stats2");
+    send_generic_stats_request("stats1");
+    send_generic_stats_request("stats2");
+    AIM_ASSERT(count1 == 2);
+    AIM_ASSERT(count2 == 2);
+
+    return TEST_PASS;
+}

--- a/modules/OFStateManager/utest/main.c
+++ b/modules/OFStateManager/utest/main.c
@@ -58,6 +58,9 @@ int test_group_table(void);
 /* Defined in port_registration_test.c */
 int test_port_registration(void);
 
+/* Defined in generic_stats_test.c */
+int test_generic_stats(void);
+
 /* Must be an even number */
 #define TEST_FLOW_COUNT 1000
 
@@ -1449,6 +1452,10 @@ aim_main(int argc, char* argv[])
     }
 
     if (test_port_registration() != TEST_PASS) {
+        return 1;
+    }
+
+    if (test_generic_stats() != TEST_PASS) {
         return 1;
     }
 

--- a/modules/indigo/module/inc/indigo/of_state_manager.h
+++ b/modules/indigo/module/inc/indigo/of_state_manager.h
@@ -638,5 +638,43 @@ indigo_core_queue_register(of_port_no_t port_no, uint32_t queue_id, struct ind_c
 void
 indigo_core_queue_unregister(struct ind_core_queue *handle);
 
+/****************************************************************
+ * Generic stats
+ ****************************************************************/
+
+/**
+ * Handle a generic stats request
+ * @param cxn_id Connection ID
+ * @param req Request message
+ * @param priv Private data passed to indigo_core_generic_stats_register
+ *
+ * This function should send one or more generic stats reply messages,
+ * setting the OFPSF_REQ_MORE flag on all but the last. It can spawn
+ * a long running task if necessary.
+ */
+typedef void (*indigo_core_generic_stats_f)(
+    indigo_cxn_id_t cxn_id,
+    const of_bsn_generic_stats_request_t *req,
+    void *priv);
+
+/**
+ * @brief Register a generic stats request
+ * @param name Name of the stats request
+ * @param handler Function pointer called when stats request is received
+ * @param priv Private data passed to handler
+ */
+void
+indigo_core_generic_stats_register(
+    const char *name,
+    indigo_core_generic_stats_f handler,
+    void *priv);
+
+/**
+ * @brief Unregister a generic stats request
+ * @param name Name of the stats request
+ */
+void
+indigo_core_generic_stats_unregister(const char *name);
+
 #endif /* _INDIGO_OF_STATE_MANAGER_H_ */
 /** @} */


### PR DESCRIPTION
Reviewer: @wilmo119

These APIs make it more convenient and efficient to use generic stats. You can 
register for a specific generic stats request instead of using a message 
listener that runs on every message.