### PR TITLE
Add queue_desc handler and port manager hooks.

### DIFF
--- a/modules/OFStateManager/module/src/handlers.h
+++ b/modules/OFStateManager/module/src/handlers.h
@@ -51,6 +51,9 @@ extern void ind_core_queue_get_config_request_handler(
 extern void ind_core_queue_stats_request_handler(
     of_object_t *_obj,
     indigo_cxn_id_t cxn);
+extern void ind_core_queue_desc_request_handler(
+    of_object_t *_obj,
+    indigo_cxn_id_t cxn);
 extern void ind_core_flow_add_handler(
     of_object_t *_obj,
     indigo_cxn_id_t cxn);

--- a/modules/OFStateManager/module/src/ofstatemanager.c
+++ b/modules/OFStateManager/module/src/ofstatemanager.c
@@ -305,6 +305,10 @@ indigo_core_receive_controller_message(indigo_cxn_id_t cxn, of_object_t *obj)
         ind_core_queue_stats_request_handler(obj, cxn);
         break;
 
+    case OF_QUEUE_DESC_STATS_REQUEST:
+        ind_core_queue_desc_request_handler(obj, cxn);
+        break;
+
     /****************************************************************
      * Group messages
      ****************************************************************/

--- a/modules/indigo/module/inc/indigo/port_manager.h
+++ b/modules/indigo/module/inc/indigo/port_manager.h
@@ -252,6 +252,32 @@ indigo_error_t indigo_port_queue_stats_get_one(
     uint32_t queue_id,
     of_queue_stats_entry_t *queue_stats) AIM_COMPILER_ATTR_WEAK;
 
+/**
+ * @brief Process an OF queue desc request
+ * @param queue_desc_request The LOXI request message
+ * @param [out] queue_desc_reply The LOXI reply message
+ * @return Return code from operation
+ *
+ * Ownership of the queue_desc_request LOXI object is maintained by the
+ * caller (OF state manager).
+ */
+
+extern indigo_error_t indigo_port_queue_desc_get(
+    of_queue_desc_stats_request_t *queue_desc_request,
+    of_queue_desc_stats_reply_t **queue_desc_reply) AIM_COMPILER_ATTR_WEAK;
+
+/**
+ * @brief Get queue description for a single queue
+ * @param port_no Port number
+ * @param queue_id Queue ID
+ * @param queue_stats LOXI object to populate
+ * @return Return code from operation
+ */
+
+indigo_error_t indigo_port_queue_desc_get_one(
+    of_port_no_t port_no,
+    uint32_t queue_id,
+    of_queue_desc_t *queue_desc) AIM_COMPILER_ATTR_WEAK;
 
 /**
  * @brief Experimenter (vendor) extension


### PR DESCRIPTION
Reviewer: @rlane 

Implementation based on queue_stats handler.
Strangely, the queue_desc_request/_reply is actually named queue_desc_stats_request/_reply; let me know if you want me to update loxigen to rename it.
