### PR TITLE
SocketManager: fix infinite timeout when no timers in next 1s

### DIFF
--- a/modules/SocketManager/module/src/socketmanager.c
+++ b/modules/SocketManager/module/src/socketmanager.c
@@ -121,6 +121,7 @@ typedef struct timer_event_s {
 static timer_event_t timer_event[SOCKETMANAGER_CONFIG_MAX_TIMERS];
 static timer_wheel_t *timer_wheel;
 static list_head_t ready_timers; /* contains timer_event_t through ready_links */
+static int num_timers = 0;
 
 #define TIMER_EVENT_VALID(idx) (timer_event[idx].callback != NULL)
 
@@ -374,7 +375,7 @@ ind_soc_run_status_set(ind_soc_run_status_t s)
 
 
 /*
- * Return the time in ms until the next timer fires, or -1 if no timers
+ * Return the time in ms until the next timer could fire, or -1 if no timers
  * are active.
  */
 static int
@@ -388,9 +389,11 @@ find_next_timer_expiration(indigo_time_t now)
         timer_wheel_peek(timer_wheel, now + SOCKETMANAGER_CONFIG_TIMER_PEEK_MS);
     if (entry) {
         return entry->deadline - now;
+    } else if (num_timers > 0) {
+        return SOCKETMANAGER_CONFIG_TIMER_PEEK_MS;
+    } else {
+        return -1;
     }
-
-    return -1;
 }
 
 /* Pull expired timers off the timer wheel and add them to the ready list */
@@ -450,6 +453,7 @@ process_timers(ind_soc_priority_t priority)
         if (timer->repeat_time_ms == IND_SOC_TIMER_IMMEDIATE) {
             /* De-register one-shot immediate timers */
             timer->state = TIMER_STATE_FREE;
+            num_timers--;
         } else {
             timer_wheel_insert(timer_wheel, &timer->timer_wheel_entry,
                                now + timer->repeat_time_ms);
@@ -508,6 +512,7 @@ ind_soc_timer_event_register_with_priority(
     timer_wheel_insert(timer_wheel, &timer_event[idx].timer_wheel_entry,
                        INDIGO_CURRENT_TIME + repeat_time_ms);
     timer_event[idx].state = TIMER_STATE_WAITING;
+    num_timers++;
 
     return INDIGO_ERROR_NONE;
 }
@@ -539,6 +544,7 @@ ind_soc_timer_event_unregister(ind_soc_timer_callback_f callback, void *cookie)
     }
 
     timer_event[idx].state = TIMER_STATE_FREE;
+    num_timers--;
 
     return INDIGO_ERROR_NONE;
 }

--- a/modules/SocketManager/module/src/socketmanager.c
+++ b/modules/SocketManager/module/src/socketmanager.c
@@ -1,6 +1,6 @@
 /****************************************************************
  *
- *        Copyright 2013, Big Switch Networks, Inc.
+ *        Copyright 2013-2016, Big Switch Networks, Inc.
  *
  * Licensed under the Eclipse Public License, Version 1.0 (the
  * "License"); you may not use this file except in compliance

--- a/modules/SocketManager/utest/main.c
+++ b/modules/SocketManager/utest/main.c
@@ -413,6 +413,24 @@ test_timer_mgmt(void)
     }
 }
 
+/*
+ * Test a timer beyond SOCKETMANAGER_CONFIG_TIMER_PEEK_MS
+ */
+static void
+test_future_timer(void)
+{
+    int count = 0;
+    INDIGO_ASSERT(ind_soc_timer_event_register(
+        timer_callback, &count, SOCKETMANAGER_CONFIG_TIMER_PEEK_MS*2) == 0);
+
+    /* Should run immediately */
+    ind_soc_select_and_run(SOCKETMANAGER_CONFIG_TIMER_PEEK_MS*3);
+    INDIGO_ASSERT(count == 1);
+
+    /* Should be unregistered after firing */
+    INDIGO_ASSERT(ind_soc_timer_event_unregister(timer_callback, &count) == 0);
+}
+
 static ind_soc_task_status_t
 task_callback(void *cookie)
 {
@@ -665,6 +683,7 @@ aim_main(int argc, char* argv[])
     test_timer_mgmt();
     test_periodic_timer();
     test_immediate_timer();
+    test_future_timer();
     test_socket();
     test_socket_mgmt();
     test_task();

--- a/modules/SocketManager/utest/main.c
+++ b/modules/SocketManager/utest/main.c
@@ -1,6 +1,6 @@
 /****************************************************************
  *
- *        Copyright 2013, Big Switch Networks, Inc.
+ *        Copyright 2013-2016, Big Switch Networks, Inc.
  *
  * Licensed under the Eclipse Public License, Version 1.0 (the
  * "License"); you may not use this file except in compliance


### PR DESCRIPTION
Reviewer: @kenchiang

We use SOCKETMANAGER_CONFIG_TIMER_PEEK_MS to limit the number of timer wheel 
buckets that need to be checked each tick of the event loop. The problem was 
that find_next_timer_expiration returned -1 (meaning infinite timeout) when 
there was no timer expiration in the next TIMER_PEEK_MS. Instead, the event 
loop should check the timers again after TIMER_PEEK_MS.

This doesn't happen in practice because another timer or socket event will
wake the event loop and it will check the timer wheel again.

The included testcase fails without the fix.