### PR TITLE
Double the maximum gentable size to 128 and added a new assertion

### DIFF
--- a/modules/OFStateManager/module/src/gentable_handlers.c
+++ b/modules/OFStateManager/module/src/gentable_handlers.c
@@ -39,7 +39,7 @@
 #include "handlers.h"
 #include <murmur/murmur.h>
 
-#define MAX_GENTABLES 64
+#define MAX_GENTABLES 128
 
 struct ind_core_gentable_entry;
 
@@ -114,6 +114,7 @@ indigo_core_gentable_register(
     AIM_TRUE_OR_DIE(ops->del != NULL || ops->del2 != NULL);
     AIM_TRUE_OR_DIE(ops->get_stats != NULL);
     AIM_TRUE_OR_DIE(buckets_size > 1);
+    AIM_TRUE_OR_DIE(strlen(name) <= OF_MAX_TABLE_NAME_LEN);
 
     struct indigo_core_gentable *gentable = aim_zmalloc(sizeof(*gentable));
 


### PR DESCRIPTION
Reviewer: @kenchiang @poolakiran 

* Double the maximum gentable size to 128, since the new gentable 'dscp_to_priority_profile' reaches the 64-gentable limit.
* Added an assertion to validate the length of a gentable name, which should not exceed 32.