### PR TITLE
Add subbundles to the bundle infrastructure.

### DIFF
--- a/modules/OFConnectionManager2/module/auto/OFConnectionManager.yml
+++ b/modules/OFConnectionManager2/module/auto/OFConnectionManager.yml
@@ -1,6 +1,6 @@
 ################################################################
 #
-#        Copyright 2013, Big Switch Networks, Inc. 
+#        Copyright 2013-2015,2017, Big Switch Networks, Inc.
 # 
 # Licensed under the Eclipse Public License, Version 1.0 (the
 # "License"); you may not use this file except in compliance
@@ -63,6 +63,9 @@ cdefs: &cdefs
 - OFCONNECTIONMANAGER_CONFIG_MAX_BUNDLE_BYTES:
     doc: "Maximum cumulative size of OpenFlow messages to allow in a bundle"
     default: 50*1024*1024
+- OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES:
+    doc: "Maximum number of subbundles in a bundle"
+    default: 1023
 
 definitions:
   cdefs:

--- a/modules/OFConnectionManager2/module/inc/OFConnectionManager/ofconnectionmanager_config.h
+++ b/modules/OFConnectionManager2/module/inc/OFConnectionManager/ofconnectionmanager_config.h
@@ -1,6 +1,6 @@
 /****************************************************************
  *
- *        Copyright 2013, Big Switch Networks, Inc.
+ *        Copyright 2013-2015,2017, Big Switch Networks, Inc.
  *
  * Licensed under the Eclipse Public License, Version 1.0 (the
  * "License"); you may not use this file except in compliance
@@ -167,6 +167,16 @@
 
 #ifndef OFCONNECTIONMANAGER_CONFIG_MAX_BUNDLE_BYTES
 #define OFCONNECTIONMANAGER_CONFIG_MAX_BUNDLE_BYTES 50*1024*1024
+#endif
+
+/**
+ * OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES
+ *
+ * Maximum number of subbundles in a bundle */
+
+
+#ifndef OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES
+#define OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES 1023
 #endif
 
 

--- a/modules/OFConnectionManager2/module/src/bundle.c
+++ b/modules/OFConnectionManager2/module/src/bundle.c
@@ -1,6 +1,6 @@
 /****************************************************************
  *
- *        Copyright 2014, Big Switch Networks, Inc.
+ *        Copyright 2014-2015,2017, Big Switch Networks, Inc.
  *
  * Licensed under the Eclipse Public License, Version 1.0 (the
  * "License"); you may not use this file except in compliance
@@ -49,13 +49,16 @@
  *  - Validate messages on add
  */
 
+/* bundle task state stores all necessary info to process a bundle's msgs;
+ * original bundle is freed immediately after task state is set up */
 struct bundle_task_state {
     indigo_cxn_id_t cxn_id;
     of_object_t *reply;
     uint32_t id; /* Bundle ID */
-    uint32_t count; /* Length of msgs array */
-    uint32_t offset; /* Current position in msgs array */
-    uint8_t **msgs; /* Array of pointers to raw message data */
+    uint32_t subbundle_count;  /* Number of subbundles */
+    uint32_t cur_subbundle;    /* Currently processing this subbundle */
+    uint32_t cur_offset;       /* Current position in current subbundle */
+    subbundle_t *subbundles;   /* Array of pointers to subbundles */
 };
 
 static bundle_t *find_bundle(connection_t *cxn, uint32_t id);
@@ -65,6 +68,19 @@ static int compare_message(const void *_a, const void *_b);
 static ind_soc_task_status_t bundle_task(void *cookie);
 
 static indigo_cxn_bundle_comparator_t comparator;
+
+/* by default, every bundle_add message goes into the same subbundle.
+ * NOTE: an extra subbundle is allocated for barriers when a subbundle
+ * designator is supplied */
+static uint32_t num_subbundles_per_bundle = 1;
+static indigo_cxn_subbundle_designator_t subbundle_designator;
+static indigo_cxn_bundle_comparator_t *subbundle_comparators;
+
+/* used by subbundle_compare_message to select subbundle comparator */
+static uint32_t subbundle_comparator_idx;
+/* forward declaration */
+static int subbundle_compare_message(const void *_a, const void *_b);
+
 
 void
 ind_cxn_bundle_init(connection_t *cxn)
@@ -117,9 +133,17 @@ ind_cxn_bundle_ctrl_handle(connection_t *cxn, of_object_t *obj)
         bundle->id = bundle_id;
         bundle->flags = flags;
         AIM_ASSERT(bundle->count == 0);
-        AIM_ASSERT(bundle->allocated == 0);
         AIM_ASSERT(bundle->bytes == 0);
-        AIM_ASSERT(bundle->msgs == NULL);
+        AIM_ASSERT(bundle->subbundle_count == 0);
+        AIM_ASSERT(bundle->subbundles == NULL);
+
+        /* allocate subbundles */
+        bundle->subbundle_count = num_subbundles_per_bundle;
+        bundle->subbundles =
+            aim_zmalloc(sizeof(subbundle_t)*bundle->subbundle_count);
+        AIM_TRUE_OR_DIE(bundle->subbundles != NULL,
+                        "no memory allocated for subbundles");
+        AIM_LOG_VERBOSE("allocated %d subbundles", bundle->subbundle_count);
     } else if (ctrl_type == OFPBCT_CLOSE_REQUEST) {
         /* Ignored */
     } else if (ctrl_type == OFPBCT_COMMIT_REQUEST) {
@@ -128,28 +152,53 @@ ind_cxn_bundle_ctrl_handle(connection_t *cxn, of_object_t *obj)
             goto error;
         }
 
-        if (comparator && !(bundle->flags & OFPBF_ORDERED)) {
-            qsort(bundle->msgs, bundle->count, sizeof(bundle->msgs[0]), compare_message);
+        AIM_LOG_VERBOSE("bundle commit, count %d", bundle->count);
+        if (bundle->subbundle_count == 1) {
+            if (comparator && !(bundle->flags & OFPBF_ORDERED)) {
+                subbundle_t *subbundle = &bundle->subbundles[0];
+                AIM_LOG_VERBOSE("qsort start");
+                qsort(subbundle->msgs, subbundle->count,
+                      sizeof(subbundle->msgs[0]), compare_message);
+                AIM_LOG_VERBOSE("qsort complete");
+            }
+        } else {
+            /* iterate over all subbundles, invoking supplied comparators;
+             * skip the last subbundle, which contains barriers only */
+            int i;
+            for (i = 0; i < bundle->subbundle_count-1; i++) {
+                if (subbundle_comparators && subbundle_comparators[i]) {
+                    subbundle_t *subbundle = &bundle->subbundles[i];
+                    subbundle_comparator_idx = i;
+                    AIM_LOG_VERBOSE("sort start for subbundle %d", i);
+                    qsort(subbundle->msgs, subbundle->count,
+                          sizeof(subbundle->msgs[0]),
+                          subbundle_compare_message);
+                    AIM_LOG_VERBOSE("sorted %d", i);
+                }
+            }
         }
 
         struct bundle_task_state *state = aim_zmalloc(sizeof(*state));
         state->cxn_id = cxn->cxn_id;
         state->reply = of_object_dup(obj);
-        of_bundle_ctrl_msg_bundle_ctrl_type_set(state->reply, OFPBCT_COMMIT_REPLY);
+        of_bundle_ctrl_msg_bundle_ctrl_type_set(state->reply,
+                                                OFPBCT_COMMIT_REPLY);
         state->id = bundle->id;
-        state->count = bundle->count;
-        state->offset = 0;
-        state->msgs = bundle->msgs;
+        state->subbundle_count = bundle->subbundle_count;
+        state->cur_subbundle = 0;
+        state->cur_offset = 0;
+        state->subbundles = bundle->subbundles;
 
-        if (ind_soc_task_register(bundle_task, state, IND_SOC_NORMAL_PRIORITY) < 0) {
+        if (ind_soc_task_register(bundle_task, state,
+                                  IND_SOC_NORMAL_PRIORITY) < 0) {
             AIM_DIE("Failed to create long running task for bundle");
         }
 
         ind_cxn_pause(cxn);
 
         /* Transfer ownership of msgs to task */
-        bundle->msgs = NULL;
-        bundle->count = 0;
+        bundle->subbundles = NULL;
+        bundle->subbundle_count = 0;
 
         free_bundle(bundle);
 
@@ -231,14 +280,34 @@ ind_cxn_bundle_add_handle(connection_t *cxn, of_object_t *obj)
         return;
     }
 
-    if (bundle->count == bundle->allocated) {
+    /* find the right subbundle */
+    int idx;
+    if (bundle->subbundle_count == 1) {
+        idx = 0;
+    } else {
+        of_object_storage_t obj_storage;
+        of_object_t *obj = parse_message(data.data, &obj_storage);
+        if (obj->object_id == OF_BARRIER_REQUEST) {
+            /* barriers are placed in the last subbundle */
+            idx = num_subbundles_per_bundle-1;
+        } else {
+            idx = subbundle_designator(obj);
+            if (idx > OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES) {
+                idx = OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES;
+            }
+        }
+    }
+    subbundle_t *subbundle = &bundle->subbundles[idx];
+
+    if (subbundle->count == subbundle->allocated) {
         /* Resize array */
-        uint32_t new_allocated = (bundle->allocated == 0 ? 1 : bundle->allocated * 2);
-        bundle->msgs = aim_realloc(bundle->msgs, sizeof(*bundle->msgs) * new_allocated);
-        bundle->allocated = new_allocated;
+        uint32_t new_allocated = (subbundle->allocated == 0 ? 1 : subbundle->allocated * 2);
+        subbundle->msgs = aim_realloc(subbundle->msgs, sizeof(*subbundle->msgs) * new_allocated);
+        subbundle->allocated = new_allocated;
     }
 
-    bundle->msgs[bundle->count++] = aim_memdup(data.data, data.bytes);
+    subbundle->msgs[subbundle->count++] = aim_memdup(data.data, data.bytes);
+    bundle->count++;
     bundle->bytes += data.bytes;
 }
 
@@ -262,23 +331,69 @@ parse_message(uint8_t *data, of_object_storage_t *storage)
     return of_object_new_from_message_preallocated(storage, data, len);
 }
 
+
+static void
+free_subbundle(subbundle_t *subbundle)
+{
+    int i;
+    for (i = 0; i < subbundle->count; i++) {
+        aim_free(subbundle->msgs[i]);
+    }
+    aim_free(subbundle->msgs);
+}
+
 static void
 free_bundle(bundle_t *bundle)
 {
     int i;
-    for (i = 0; i < bundle->count; i++) {
-        aim_free(bundle->msgs[i]);
+    for (i = 0; i < bundle->subbundle_count; i++) {
+        free_subbundle(&bundle->subbundles[i]);
     }
-
-    aim_free(bundle->msgs);
+    aim_free(bundle->subbundles);
 
     bundle->id = BUNDLE_ID_INVALID;
-    bundle->msgs = NULL;
+    bundle->subbundles = NULL;
+    bundle->subbundle_count = 0;
     bundle->count = 0;
-    bundle->allocated = 0;
     bundle->bytes = 0;
     bundle->flags = 0;
+}
 
+/* see description in public header file */
+void
+indigo_cxn_subbundle_set(uint32_t num_subbundles,
+                         indigo_cxn_subbundle_designator_t designator,
+                         indigo_cxn_bundle_comparator_t comparators[])
+{
+    /* one more subbundle for barriers */
+    num_subbundles_per_bundle = num_subbundles + 1;
+    if (num_subbundles_per_bundle >
+        OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES+1) {
+        num_subbundles_per_bundle =
+            OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES+1;
+    }
+    subbundle_designator = designator;
+    subbundle_comparators = comparators;
+}
+
+/* WARNING: uses global variable to select the right subbundle comparator */
+static int
+subbundle_compare_message(const void *_a, const void *_b)
+{
+    AIM_ASSERT((subbundle_comparators != NULL) &&
+               (subbundle_comparator_idx < num_subbundles_per_bundle));
+
+    of_object_storage_t obj_a_storage;
+    of_object_t *obj_a = parse_message(*(uint8_t * const *)_a, &obj_a_storage);
+
+    of_object_storage_t obj_b_storage;
+    of_object_t *obj_b = parse_message(*(uint8_t * const *)_b, &obj_b_storage);
+
+    if (obj_a == NULL || obj_b == NULL) {
+        return 0;
+    }
+
+    return subbundle_comparators[subbundle_comparator_idx](obj_a, obj_b);
 }
 
 void
@@ -317,22 +432,31 @@ bundle_task(void *cookie)
 
     connection_t *cxn = ind_cxn_id_to_connection(state->cxn_id);
 
-    while (state->offset < state->count) {
-        if (cxn) {
-            of_object_storage_t obj_storage;
-            of_object_t *obj = parse_message(state->msgs[state->offset], &obj_storage);
-            ind_cxn_process_message(cxn, obj);
-        } else {
-            /* Connection went away. Drop remaining messages. */
-        }
+    while (state->cur_subbundle < state->subbundle_count) {
+        subbundle_t *subbundle = &state->subbundles[state->cur_subbundle];
+        /* iterate through the current subbundle */
+        while (state->cur_offset < subbundle->count) {
+            if (cxn) {
+                of_object_storage_t obj_storage;
+                of_object_t *obj =
+                    parse_message(subbundle->msgs[state->cur_offset],
+                                  &obj_storage);
+                ind_cxn_process_message(cxn, obj);
+            } else {
+                /* Connection went away. Drop remaining messages. */
+            }
 
-        aim_free(state->msgs[state->offset]);
-        state->msgs[state->offset] = NULL;
-        state->offset++;
+            aim_free(subbundle->msgs[state->cur_offset]);
+            subbundle->msgs[state->cur_offset] = NULL;
+            state->cur_offset++;
 
-        if (ind_soc_should_yield()) {
-            return IND_SOC_TASK_CONTINUE;
+            if (ind_soc_should_yield()) {
+                return IND_SOC_TASK_CONTINUE;
+            }
         }
+        /* move to the next subbundle */
+        state->cur_subbundle++;
+        state->cur_offset = 0;
     }
 
     if (cxn) {
@@ -341,7 +465,7 @@ bundle_task(void *cookie)
         of_object_delete(state->reply);
     }
 
-    aim_free(state->msgs);
+    aim_free(state->subbundles);
     aim_free(state);
 
     if (cxn) {

--- a/modules/OFConnectionManager2/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.h
@@ -1,6 +1,6 @@
 /****************************************************************
  *
- *        Copyright 2013-2015, Big Switch Networks, Inc.
+ *        Copyright 2013-2015,2017, Big Switch Networks, Inc.
  *
  * Licensed under the Eclipse Public License, Version 1.0 (the
  * "License"); you may not use this file except in compliance
@@ -162,13 +162,19 @@ typedef enum cxn_state_e {
 #define MAX_BUNDLES 4
 #define BUNDLE_ID_INVALID (-1)
 
+typedef struct subbundle_s {
+    uint32_t count; /* Number of messages in subbundle */
+    uint32_t allocated; /* Length of msgs array */
+    uint8_t **msgs; /* Array of pointers to raw message data */
+} subbundle_t;
+
 typedef struct bundle_s {
     uint32_t id;    /* Supplied by controller when bundle is opened */
     uint32_t count; /* Number of messages in bundle */
-    uint32_t allocated; /* Length of msgs array */
     uint32_t bytes; /* Sum of message sizes */
     uint16_t flags; /* Copied from flags field in bundle-open request */
-    uint8_t **msgs; /* Array of pointers to raw message data */
+    uint32_t subbundle_count;  /* Number of subbundles */
+    subbundle_t *subbundles; /* Array of pointers to subbundles */
 } bundle_t;
 
 

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager_config.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager_config.c
@@ -1,6 +1,6 @@
 /****************************************************************
  *
- *        Copyright 2013, Big Switch Networks, Inc.
+ *        Copyright 2013-2017, Big Switch Networks, Inc.
  *
  * Licensed under the Eclipse Public License, Version 1.0 (the
  * "License"); you may not use this file except in compliance
@@ -106,6 +106,11 @@ ofconnectionmanager_config_settings_t ofconnectionmanager_config_settings[] =
     { __ofconnectionmanager_config_STRINGIFY_NAME(OFCONNECTIONMANAGER_CONFIG_MAX_BUNDLE_BYTES), __ofconnectionmanager_config_STRINGIFY_VALUE(OFCONNECTIONMANAGER_CONFIG_MAX_BUNDLE_BYTES) },
 #else
 { OFCONNECTIONMANAGER_CONFIG_MAX_BUNDLE_BYTES(__ofconnectionmanager_config_STRINGIFY_NAME), "__undefined__" },
+#endif
+#ifdef OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES
+    { __ofconnectionmanager_config_STRINGIFY_NAME(OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES), __ofconnectionmanager_config_STRINGIFY_VALUE(OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES) },
+#else
+{ OFCONNECTIONMANAGER_CONFIG_MAX_SUBBUNDLES(__ofconnectionmanager_config_STRINGIFY_NAME), "__undefined__" },
 #endif
     { NULL, NULL }
 };

--- a/modules/OFConnectionManager2/utest/main.c
+++ b/modules/OFConnectionManager2/utest/main.c
@@ -390,6 +390,8 @@ of_send_bundled_echo(bool is_tls, intptr_t tl, uint32_t xid)
     of_octets_t octs = { .data = data,
                          .bytes = of_message_length_get(data) };
     of_send_bundle_add(is_tls, tl, &octs);
+    aim_free(data);
+    of_object_delete(echo);
 }
 
 static void
@@ -403,6 +405,8 @@ of_send_bundled_barrier(bool is_tls, intptr_t tl, uint32_t xid)
     of_octets_t octs = { .data = data,
                          .bytes = of_message_length_get(data) };
     of_send_bundle_add(is_tls, tl, &octs);
+    aim_free(data);
+    of_object_delete(barrier);
 }
 
 static of_object_t *

--- a/modules/SocketManager/module/src/socketmanager.c
+++ b/modules/SocketManager/module/src/socketmanager.c
@@ -195,6 +195,11 @@ soc_mgr_init(void)
     latency_histogram = histogram_create("socman.latency");
 }
 
+static void
+soc_mgr_denit(void)
+{
+    histogram_destroy(latency_histogram);
+}
 
 indigo_error_t
 ind_soc_socket_register_with_priority(int socket_id,
@@ -681,7 +686,7 @@ ind_soc_finish(void)
 {
     AIM_LOG_VERBOSE("Shutting down socket manager");
     ind_cfg_unregister(&ind_soc_cfg_ops);
-    soc_mgr_init();
+    soc_mgr_denit();
     timer_wheel_destroy(timer_wheel);
     timer_wheel = NULL;
     init_done = 0;

--- a/modules/indigo/module/inc/indigo/of_connection_manager.h
+++ b/modules/indigo/module/inc/indigo/of_connection_manager.h
@@ -745,10 +745,12 @@ typedef uint32_t (*indigo_cxn_subbundle_designator_t)(of_object_t *obj);
  * @param num_subbundles Number of subbundles in a bundle
  * @param designator Returns the subbundle to which the input message is added
  * @param comparators Array of comparators for sorting subbundles
+ * @return INDIGO_ERROR_PARAM if input parameters are invalid,
+ *    INDIGO_ERROR_NONE otherwise
  *
  * To disable subbundling, use "indigo_cxn_subbundle_set(0, NULL, NULL);"
  */
-void
+indigo_error_t
 indigo_cxn_subbundle_set(uint32_t num_subbundles,
                          indigo_cxn_subbundle_designator_t designator,
                          indigo_cxn_bundle_comparator_t comparators[]);


### PR DESCRIPTION
Reviewer: @poolakiran 
The majority of messages added to a bundle do not need to be sorted, but only need to be processed in a specified order.
So we distribute the messages into subbundles and only sort the necessary subbundles.