### PR TITLE
In bundle handling, check connection is still usable before resuming

### DIFF
--- a/modules/OFConnectionManager2/module/src/bundle.c
+++ b/modules/OFConnectionManager2/module/src/bundle.c
@@ -533,7 +533,7 @@ bundle_task(void *cookie)
     aim_free(state->subbundles);
     aim_free(state);
 
-    if (cxn) {
+    if (cxn && ind_cxn_is_handshake_complete(cxn)) {
         ind_cxn_resume(cxn);
     }
 


### PR DESCRIPTION
Reviewer: @poolakiran 
This should prevent trying to resume a connection whose socket descriptor has already been closed and invalidated (cxn->sd == -1).