### PR TITLE
Move cxn sanity checking downwards from bundle handler into ind_cxn_resume

### DIFF
--- a/modules/OFConnectionManager2/module/src/bundle.c
+++ b/modules/OFConnectionManager2/module/src/bundle.c
@@ -533,9 +533,7 @@ bundle_task(void *cookie)
     aim_free(state->subbundles);
     aim_free(state);
 
-    if (cxn && ind_cxn_is_handshake_complete(cxn)) {
-        ind_cxn_resume(cxn);
-    }
+    ind_cxn_resume(cxn);
 
     return IND_SOC_TASK_FINISHED;
 }

--- a/modules/OFConnectionManager2/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.c
@@ -2157,9 +2157,15 @@ ind_cxn_pause(connection_t *cxn)
 void
 ind_cxn_resume(connection_t *cxn)
 {
+    if (cxn == NULL) {
+        return;
+    }
+
     AIM_ASSERT(cxn->pause_refcount > 0);
     if (--cxn->pause_refcount == 0) {
-        set_cxn_read_write_events(cxn);
+        if (ind_cxn_is_handshake_complete(cxn)) {
+            set_cxn_read_write_events(cxn);
+        }
     }
 }
 


### PR DESCRIPTION
Reviewer: @poolakiran 
Then callers of ind_cxn_resume do not need to sanity check the connection.
