### PR TITLE
Its possible for find_next_timer_expiration() to return a negative value

### DIFF
--- a/modules/SocketManager/module/src/socketmanager.c
+++ b/modules/SocketManager/module/src/socketmanager.c
@@ -393,6 +393,12 @@ find_next_timer_expiration(indigo_time_t now)
     timer_wheel_entry_t *entry =
         timer_wheel_peek(timer_wheel, now + SOCKETMANAGER_CONFIG_TIMER_PEEK_MS);
     if (entry) {
+        /* if the timer is late getting serviced, return 0 */
+        if (now > entry->deadline) {
+            AIM_LOG_TRACE("find_next_timer_expiration deadline late:",
+                          "now, %ld deadline %ld", now, entry->deadline);
+            return 0;
+        }
         return entry->deadline - now;
     } else if (num_timers > 0) {
         return SOCKETMANAGER_CONFIG_TIMER_PEEK_MS;


### PR DESCRIPTION
which calculate_next_timeout() presumes to be -1, which then requests
an infinite timeout, even tho find_next_timer_expiration() identifies
that the timer is past its deadline

Reviewer: @kenchiang @wilmo119 @amospaul-bsn 