### PR TITLE
Adjust strncpy destination or byte count to avoid compiler warning

### DIFF
--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -338,11 +338,11 @@ controller_t_init(controller_t *controller,
  *------------------------------------------------------------*/
 
 typedef struct tls_cfg_s {
-    char cipher_list[INDIGO_TLS_CFG_PARAM_LEN];
-    char ca_cert[INDIGO_TLS_CFG_PARAM_LEN];
-    char switch_cert[INDIGO_TLS_CFG_PARAM_LEN];
-    char switch_priv_key[INDIGO_TLS_CFG_PARAM_LEN];
-    char exp_controller_suffix[INDIGO_TLS_CFG_PARAM_LEN];
+    char cipher_list[INDIGO_TLS_CFG_PARAM_LEN+1];
+    char ca_cert[INDIGO_TLS_CFG_PARAM_LEN+1];
+    char switch_cert[INDIGO_TLS_CFG_PARAM_LEN+1];
+    char switch_priv_key[INDIGO_TLS_CFG_PARAM_LEN+1];
+    char exp_controller_suffix[INDIGO_TLS_CFG_PARAM_LEN+1];
     bool check_controller_suffix;
 } tls_cfg_t;
 
@@ -580,19 +580,19 @@ indigo_cxn_config_tls(char *cipher_list,
                             switch_cert, switch_priv_key,
                             exp_controller_suffix);
     if (rv == INDIGO_ERROR_NONE) {
-        strncpy(tls_cfg.cipher_list, cipher_list, sizeof(tls_cfg.cipher_list));
+        strncpy(tls_cfg.cipher_list, cipher_list, INDIGO_TLS_CFG_PARAM_LEN);
         if (ca_cert) {
-            strncpy(tls_cfg.ca_cert, ca_cert, sizeof(tls_cfg.ca_cert));
+            strncpy(tls_cfg.ca_cert, ca_cert, INDIGO_TLS_CFG_PARAM_LEN);
         } else {
-            memset(tls_cfg.ca_cert, 0, sizeof(tls_cfg.ca_cert));
+            memset(tls_cfg.ca_cert, 0, INDIGO_TLS_CFG_PARAM_LEN);
         }
-        strncpy(tls_cfg.switch_cert, switch_cert, sizeof(tls_cfg.switch_cert));
+        strncpy(tls_cfg.switch_cert, switch_cert, INDIGO_TLS_CFG_PARAM_LEN);
         strncpy(tls_cfg.switch_priv_key, switch_priv_key,
-                sizeof(tls_cfg.switch_priv_key));
+                INDIGO_TLS_CFG_PARAM_LEN);
         if (exp_controller_suffix && (exp_controller_suffix[0] != '\0')) {
             tls_cfg.check_controller_suffix = true;
             strncpy(tls_cfg.exp_controller_suffix, exp_controller_suffix,
-                    sizeof(tls_cfg.exp_controller_suffix));
+                    INDIGO_TLS_CFG_PARAM_LEN);
         } else {
             tls_cfg.check_controller_suffix = false;
             memset(tls_cfg.exp_controller_suffix, 0,
@@ -1940,7 +1940,7 @@ indigo_cxn_send_bsn_error(indigo_cxn_id_t cxn_id, of_object_t *orig,
     }
 
     of_bsn_error_xid_set(err, xid);
-    strncpy(dst_txt, err_txt, sizeof(dst_txt));
+    strncpy(dst_txt, err_txt, OF_DESC_STR_LEN-1);
     of_bsn_error_err_msg_set(err, dst_txt);
 
     if (of_bsn_error_data_set(err, &payload) < 0) {
@@ -1992,7 +1992,7 @@ indigo_cxn_send_bsn_gentable_error(indigo_cxn_id_t cxn_id,
     of_bsn_gentable_error_xid_set(err, xid);
     of_bsn_gentable_error_table_id_set(err, gentable_id);
     of_bsn_gentable_error_error_code_set(err, code);
-    strncpy(dst_txt, err_txt, sizeof(dst_txt));
+    strncpy(dst_txt, err_txt, OF_DESC_STR_LEN-1);
     of_bsn_gentable_error_err_msg_set(err, dst_txt);
 
     if (of_bsn_gentable_error_data_set(err, &payload) < 0) {

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager_config.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager_config.c
@@ -162,11 +162,11 @@ static struct config {
     int keepalive_period_ms;
     int num_controllers;
     struct controller controllers[MAX_CONTROLLERS];
-    char cipher_list[INDIGO_TLS_CFG_PARAM_LEN];
-    char ca_cert[INDIGO_TLS_CFG_PARAM_LEN];
-    char switch_cert[INDIGO_TLS_CFG_PARAM_LEN];
-    char switch_priv_key[INDIGO_TLS_CFG_PARAM_LEN];
-    char exp_controller_suffix[INDIGO_TLS_CFG_PARAM_LEN];
+    char cipher_list[INDIGO_TLS_CFG_PARAM_LEN+1];
+    char ca_cert[INDIGO_TLS_CFG_PARAM_LEN+1];
+    char switch_cert[INDIGO_TLS_CFG_PARAM_LEN+1];
+    char switch_priv_key[INDIGO_TLS_CFG_PARAM_LEN+1];
+    char exp_controller_suffix[INDIGO_TLS_CFG_PARAM_LEN+1];
     int valid;
 } staged_config, current_config;
 

--- a/modules/OFStateManager/module/src/bsn_debug_counter_handlers.c
+++ b/modules/OFStateManager/module/src/bsn_debug_counter_handlers.c
@@ -65,11 +65,11 @@ ind_core_bsn_debug_counter_desc_stats_request_handler(of_object_t *_obj,
         of_bsn_debug_counter_desc_stats_entry_counter_id_set(entry, counter->counter_id);
 
         memset(name, 0, sizeof(name));
-        strncpy(name, counter->name, sizeof(name));
+        strncpy(name, counter->name, sizeof(name)-1);
         of_bsn_debug_counter_desc_stats_entry_name_set(entry, name);
 
         memset(description, 0, sizeof(description));
-        strncpy(description, counter->description, sizeof(description));
+        strncpy(description, counter->description, sizeof(description)-1);
         of_bsn_debug_counter_desc_stats_entry_description_set(entry, description);
 
         if (of_list_append(&entries, entry) < 0) {

--- a/modules/OFStateManager/module/src/group_handlers.c
+++ b/modules/OFStateManager/module/src/group_handlers.c
@@ -482,7 +482,7 @@ void indigo_core_group_table_register(
     AIM_TRUE_OR_DIE(strlen(name) <= OF_MAX_TABLE_NAME_LEN);
 
     ind_core_group_table_t *table = aim_zmalloc(sizeof(*table));
-    strncpy(table->name, name, sizeof(table->name));
+    strncpy(table->name, name, sizeof(table->name)-1);
     table->ops = ops;
     table->priv = priv;
 

--- a/modules/OFStateManager/module/src/table.c
+++ b/modules/OFStateManager/module/src/table.c
@@ -48,7 +48,7 @@ void indigo_core_table_register(uint8_t table_id, const char *name,
     }
 
     ind_core_table_t *table = aim_zmalloc(sizeof(*table));
-    strncpy(table->name, name, sizeof(table->name));
+    strncpy(table->name, name, sizeof(table->name)-1);
     table->ops = ops;
     table->priv = priv;
     table->num_flows = 0;


### PR DESCRIPTION
Reviewer: @poolakiran @rizard 
CC: @ronaldchl 

Increase strncpy destination when possible, or reduce byte count if destination uses a datatype whose length is fixed.
