### PR TITLE
SWL-5993 Use of_object in bundle and duplicate the of_object for async call

### DIFF
--- a/modules/OFConnectionManager2/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.h
@@ -164,8 +164,8 @@ typedef enum cxn_state_e {
 
 typedef struct subbundle_s {
     uint32_t count; /* Number of messages in subbundle */
-    uint32_t allocated; /* Length of msgs array */
-    uint8_t **msgs; /* Array of pointers to raw message data */
+    uint32_t allocated; /* Length of msgs(objs) array */
+    of_object_t **objs; /* Array of pointer to of_object */
 } subbundle_t;
 
 typedef struct bundle_s {

--- a/modules/OFConnectionManager2/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.h
@@ -164,7 +164,7 @@ typedef enum cxn_state_e {
 
 typedef struct subbundle_s {
     uint32_t count; /* Number of messages in subbundle */
-    uint32_t allocated; /* Length of msgs(objs) array */
+    uint32_t allocated; /* Length of objs array */
     of_object_t **objs; /* Array of pointer to of_object */
 } subbundle_t;
 

--- a/modules/OFStateManager/module/src/handlers.h
+++ b/modules/OFStateManager/module/src/handlers.h
@@ -27,6 +27,7 @@
 #define _OF_STATE_HANDLERS_H_
 
 #include <loci/loci.h>
+#include <AIM/aim_pvs.h>
 #include <indigo/of_connection_manager.h>
 
 /* handlers.c */
@@ -204,5 +205,16 @@ void
 ind_core_bsn_generic_stats_request_handler(
     of_object_t *_obj,
     indigo_cxn_id_t cxn_id);
+
+/* gentable async debug */
+void
+ind_core_bsn_gentable_outstanding_async_ops(aim_pvs_t *pvs);
+
+/* bsn gentable handler init() and finish() */
+void
+ind_core_bsn_gentable_handler_init(void);
+
+void
+ind_core_bsn_gentable_handler_finish(void);
 
 #endif /* _OF_STATE_HANDLERS_H_ */

--- a/modules/OFStateManager/module/src/ofstatemanager.c
+++ b/modules/OFStateManager/module/src/ofstatemanager.c
@@ -719,6 +719,8 @@ ind_core_finish(void)
 {
     AIM_LOG_TRACE("OF state mgr finish called");
 
+    ind_core_bsn_gentable_handler_finish();
+
     /* Indicate core is shutting down */
     if (ind_core_module_enabled) {
         AIM_LOG_VERBOSE("Finish is calling disable");
@@ -761,6 +763,7 @@ ind_core_sw_desc_get(of_desc_str_t desc)
     INDIGO_MEM_COPY(desc, ind_core_of_config.desc_stats.sw_desc,
                     OF_DESC_STR_LEN);
 
+    ind_core_bsn_gentable_handler_init();
     return INDIGO_ERROR_NONE;
 }
 

--- a/modules/OFStateManager/module/src/ofstatemanager.c
+++ b/modules/OFStateManager/module/src/ofstatemanager.c
@@ -621,6 +621,8 @@ ind_core_init(ind_core_config_t *config)
 
     ind_core_histogram_handlers_init();
 
+    ind_core_bsn_gentable_handler_init();
+
     ind_core_init_done = 1;
 
     return INDIGO_ERROR_NONE;
@@ -763,7 +765,6 @@ ind_core_sw_desc_get(of_desc_str_t desc)
     INDIGO_MEM_COPY(desc, ind_core_of_config.desc_stats.sw_desc,
                     OF_DESC_STR_LEN);
 
-    ind_core_bsn_gentable_handler_init();
     return INDIGO_ERROR_NONE;
 }
 

--- a/modules/OFStateManager/module/src/ofstatemanager_int.h
+++ b/modules/OFStateManager/module/src/ofstatemanager_int.h
@@ -80,12 +80,16 @@ calc_duration(indigo_time_t current_time, indigo_time_t entry_time,
 /**
  * @brief Opaque handle to an operation
  */
+#define INDIGO_ASYNC_OP_CTX_MAGIC     0xaabbccdd
 typedef struct indigo_core_op_context {
+    uint32_t magic;           /* memory protection. Internal usage. */
     indigo_cxn_id_t cxn_id;
     of_object_t *obj;
+    bool free_obj;            /* free the object in resume call */
     bool no_async;            /* indication this op context is not called for async operation.
                                * It is used in the OFStatemManager internally.
                                */
+    bool invalid_ctx;         /* OFStateManager internal usage */
 } indigo_core_op_context_t;
 
 extern const struct ind_cfg_ops ind_core_cfg_ops;

--- a/modules/OFStateManager/module/src/ofstatemanager_int.h
+++ b/modules/OFStateManager/module/src/ofstatemanager_int.h
@@ -82,14 +82,13 @@ calc_duration(indigo_time_t current_time, indigo_time_t entry_time,
  */
 #define INDIGO_ASYNC_OP_CTX_MAGIC     0xaabbccdd
 typedef struct indigo_core_op_context {
-    uint32_t magic;           /* memory protection. Internal usage. */
     indigo_cxn_id_t cxn_id;
     of_object_t *obj;
-    bool free_obj;            /* free the object in resume call */
     bool no_async;            /* indication this op context is not called for async operation.
                                * It is used in the OFStatemManager internally.
+                               * It also indicates that this context and obj are not allocated
+                               * dynamically.
                                */
-    bool invalid_ctx;         /* OFStateManager internal usage */
 } indigo_core_op_context_t;
 
 extern const struct ind_cfg_ops ind_core_cfg_ops;

--- a/modules/OFStateManager/module/src/ofstatemanager_int.h
+++ b/modules/OFStateManager/module/src/ofstatemanager_int.h
@@ -80,15 +80,17 @@ calc_duration(indigo_time_t current_time, indigo_time_t entry_time,
 /**
  * @brief Opaque handle to an operation
  */
-#define INDIGO_ASYNC_OP_CTX_MAGIC     0xaabbccdd
 typedef struct indigo_core_op_context {
+    list_links_t links;
     indigo_cxn_id_t cxn_id;
     of_object_t *obj;
-    bool no_async;            /* indication this op context is not called for async operation.
-                               * It is used in the OFStatemManager internally.
-                               * It also indicates that this context and obj are not allocated
-                               * dynamically.
+    bool no_async;            /* indicate this op context is not for async operation.
+                               * It is used by the OFStatemManager internally for
+                               * entry deletion.
+                               * It also indicates that this context and obj are not
+                               * allocated dynamically.
                                */
+     indigo_time_t entry_time;
 } indigo_core_op_context_t;
 
 extern const struct ind_cfg_ops ind_core_cfg_ops;

--- a/modules/OFStateManager/module/src/ofstatemanager_ucli.c
+++ b/modules/OFStateManager/module/src/ofstatemanager_ucli.c
@@ -26,6 +26,7 @@
  *****************************************************************************/
 
 #include <indigo/types.h>
+#include "handlers.h"
 #include <OFStateManager/ofstatemanager_config.h>
 
 
@@ -34,6 +35,17 @@
 #include <uCli/ucli.h>
 #include <uCli/ucli_argparse.h>
 #include <uCli/ucli_handler_macros.h>
+
+
+static ucli_status_t
+ofstatemanager_ucli_ucli__gt_outstanding_async_op__(ucli_context_t* uc)
+{
+    UCLI_COMMAND_INFO(uc,
+                      "gt_outstanding_async_op", 0,
+                      "$summary#show current gentable outstanding async op.");
+    ind_core_bsn_gentable_outstanding_async_ops(&uc->pvs); 
+    return UCLI_STATUS_OK;
+}
 
 
 
@@ -59,6 +71,7 @@ ofstatemanager_ucli_ucli__config__(ucli_context_t* uc)
 static ucli_command_handler_f ofstatemanager_ucli_ucli_handlers__[] =
 {
     ofstatemanager_ucli_ucli__config__,
+    ofstatemanager_ucli_ucli__gt_outstanding_async_op__,
     NULL
 };
 /******************************************************************************/


### PR DESCRIPTION
Reviewer: @kenchiang @poolakiran @wilmo119 
Store the of_objects in subbundles instead of msg. This change can support the future batch process.
Duplicate the object before calling the async APIs - object will be valid when resume API is called even the connection is gone.