### PR TITLE
swl-6249 handle POLLHUP

### DIFF
--- a/modules/OFConnectionManager2/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.c
@@ -1619,7 +1619,7 @@ cxn_socket_ready(
             cxn->controller->badfd_count++;
         } else if (error_seen & POLLHUP) {
             LOG_INFO(cxn, "socket disconnected");
-            cxn->controller->disconnected_count++;
+            cxn->controller->hup_count++;
         } else {
             int socket_error = 0;
             socklen_t len = sizeof(socket_error);

--- a/modules/OFConnectionManager2/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.c
@@ -1614,7 +1614,6 @@ cxn_socket_ready(
     AIM_ASSERT(cxn->sd == socket_id);
 
     if (error_seen) {
-        int socket_error = 0;
         if (error_seen & POLLNVAL) {
             LOG_INFO(cxn, "socket has bad file descriptor");
             cxn->controller->badfd_count++;
@@ -1622,6 +1621,7 @@ cxn_socket_ready(
             LOG_INFO(cxn, "socket disconnected");
             cxn->controller->disconnected_count++;
         } else {
+            int socket_error = 0;
             socklen_t len = sizeof(socket_error);
             getsockopt(cxn->sd, SOL_SOCKET, SO_ERROR, &socket_error, &len);
             if (cxn->aux_id == 0 && socket_error == ECONNREFUSED) {

--- a/modules/OFConnectionManager2/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.h
@@ -114,8 +114,7 @@ typedef struct controller_s {
                            * cleared when TCP connection is established */
     uint32_t connect_fail_count;  /* For debug: Increments each time a main cxn attempt fails;
                                    * iand is not cleared */
-    uint32_t disconnected_count; /* Receive POLLHUP. See poll(3).
-                                  * Socket should be closed immediately. */
+    uint32_t hup_count; /* Receive POLLHUP. See poll(3). Close socket immediately. */
     uint32_t badfd_count; /* Receive POLLNVAL. See poll(3). Socket should be reopen. */
     indigo_controller_id_t controller_id;
 

--- a/modules/OFConnectionManager2/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.h
@@ -112,6 +112,8 @@ typedef struct controller_s {
                        * is disconnected? */
     uint32_t fail_count;  /* Increments each time a main cxn attempt fails;
                            * cleared when TCP connection is established */
+    uint32_t disconnected_count; /* Receive POLLHUP. See poll(3).
+                                  * Socket should be closed immediately. */
     indigo_controller_id_t controller_id;
 
     uint32_t num_aux; /* Auxillary connection count */

--- a/modules/OFConnectionManager2/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.h
@@ -112,8 +112,8 @@ typedef struct controller_s {
                        * is disconnected? */
     uint32_t fail_count;  /* Increments each time a main cxn attempt fails;
                            * cleared when TCP connection is established */
-    uint32_t connect_fail_count;  /* Increments each time a main cxn attempt fails;
-                                   * this is for debug purpose */
+    uint32_t connect_fail_count;  /* For debug: Increments each time a main cxn attempt fails;
+                                   * iand is not cleared */
     uint32_t disconnected_count; /* Receive POLLHUP. See poll(3).
                                   * Socket should be closed immediately. */
     uint32_t badfd_count; /* Receive POLLNVAL. See poll(3). Socket should be reopen. */

--- a/modules/OFConnectionManager2/module/src/cxn_instance.h
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.h
@@ -112,8 +112,11 @@ typedef struct controller_s {
                        * is disconnected? */
     uint32_t fail_count;  /* Increments each time a main cxn attempt fails;
                            * cleared when TCP connection is established */
+    uint32_t connect_fail_count;  /* Increments each time a main cxn attempt fails;
+                                   * this is for debug purpose */
     uint32_t disconnected_count; /* Receive POLLHUP. See poll(3).
                                   * Socket should be closed immediately. */
+    uint32_t badfd_count; /* Receive POLLNVAL. See poll(3). Socket should be reopen. */
     indigo_controller_id_t controller_id;
 
     uint32_t num_aux; /* Auxillary connection count */
@@ -196,6 +199,7 @@ typedef struct connection_s {
     indigo_cxn_status_t status;
 
     bool active; /* Has this connection instance been configured? */
+    bool is_accepted_socket; /* sd comes from accept() call. For debug. */
     indigo_cxn_id_t cxn_id; /* For back tracking */
 
     int sd; /* The socket descriptor */

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -703,7 +703,7 @@ listen_socket_ready(int socket_id, void *cookie, int read_ready,
                 listen_cxn->controller->badfd_count++;
             } else if (error_seen & POLLHUP) {
                 AIM_LOG_INFO("Listen cxn %s: socket disconnected", listen_cxn->desc);
-                listen_cxn->controller->disconnected_count++;
+                listen_cxn->controller->hup_count++;
             }
             /* listen cxn doesn't go through connection state.
              * FIXME: listen connection is not a "restartable" case.

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -699,13 +699,17 @@ listen_socket_ready(int socket_id, void *cookie, int read_ready,
     if (error_seen) {
         if (error_seen & (POLLNVAL | POLLHUP)) {
             if (error_seen & POLLNVAL) {
-                AIM_LOG_INFO("Listen cxn %s: socket has bad file descriptor", listen_cxn->desc);
+                AIM_LOG_INFO("Listen cxn %s: socket has a bad file descriptor", listen_cxn->desc);
                 listen_cxn->controller->badfd_count++;
             } else if (error_seen & POLLHUP) {
                 AIM_LOG_INFO("Listen cxn %s: socket disconnected", listen_cxn->desc);
                 listen_cxn->controller->disconnected_count++;
             }
-            /* listen cxn doesn't go through connection state */
+            /* listen cxn doesn't go through connection state.
+             * FIXME: listen connection is not a "restartable" case.
+             * Once error happens, it cannot be recovered.
+             * Find a way to restart it if needed.
+             */
             ind_soc_socket_unregister(listen_cxn->sd);
             close(listen_cxn->sd);
             listen_cxn->sd = -1;

--- a/modules/SocketManager/module/src/socketmanager.c
+++ b/modules/SocketManager/module/src/socketmanager.c
@@ -773,6 +773,12 @@ process_sockets(ind_soc_priority_t priority)
         read_ready = (pfd->revents & POLLIN) != 0;
         write_ready = (pfd->revents & POLLOUT) != 0;
         error_seen = (pfd->revents & POLLERR) != 0;
+        /* POLLHUP only applied on socket. See poll(3) manpage.
+         * Let the callback to handle the error.
+         */
+        if (pfd->revents & POLLHUP) {
+            error_seen = POLLHUP;
+        }
         if (read_ready || write_ready || error_seen) {
             before_callback();
             soc_map[pfd->fd].callback(pfd->fd, soc_map[pfd->fd].cookie,

--- a/modules/SocketManager/module/src/socketmanager.c
+++ b/modules/SocketManager/module/src/socketmanager.c
@@ -772,17 +772,11 @@ process_sockets(ind_soc_priority_t priority)
 
         read_ready = (pfd->revents & POLLIN) != 0;
         write_ready = (pfd->revents & POLLOUT) != 0;
-        error_seen = (pfd->revents & POLLERR) != 0;
         /* POLLHUP only applied on socket. See poll(3) manpage.
          * Let the callback to handle the error.
          * POLLNVAL is an invalid fd case. In case of reuse of an old fd.
          */
-        if (pfd->revents & POLLHUP) {
-            error_seen |= POLLHUP;
-        }
-        if (pfd->revents & POLLNVAL) {
-            error_seen |= POLLNVAL;
-        }
+        error_seen = (pfd->revents & (POLLERR | POLLHUP | POLLNVAL));
         if (read_ready || write_ready || error_seen) {
             before_callback();
             soc_map[pfd->fd].callback(pfd->fd, soc_map[pfd->fd].cookie,

--- a/modules/SocketManager/module/src/socketmanager.c
+++ b/modules/SocketManager/module/src/socketmanager.c
@@ -775,9 +775,13 @@ process_sockets(ind_soc_priority_t priority)
         error_seen = (pfd->revents & POLLERR) != 0;
         /* POLLHUP only applied on socket. See poll(3) manpage.
          * Let the callback to handle the error.
+         * POLLNVAL is an invalid fd case. In case of reuse of an old fd.
          */
         if (pfd->revents & POLLHUP) {
-            error_seen = POLLHUP;
+            error_seen |= POLLHUP;
+        }
+        if (pfd->revents & POLLNVAL) {
+            error_seen |= POLLNVAL;
         }
         if (read_ready || write_ready || error_seen) {
             before_callback();


### PR DESCRIPTION
Reviewer: @poolakiran @kenchiang 
After debug further, the file descriptor 196 has the POLLHUP which the existing codes don't handle it. Based on the poll(3), we may need to handle the POLLHUP to close the file descriptor.
Note: From the pollfds in core file, the fd 196 had the revents value 32 which is POLLHUP.