### PR TITLE
Invoke python3 in init.mk; convert submodules/init.py to python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ Run `make check`.  This will build and run each module's unit test.  In
 general, you will see a lot of output and occasionally even error messages
 for tests that exercise error handling.
 
-Use the VERBOSE=1 and valgrind environment variables for building problems.
-Example: "make VERBOSE=1" . "make VALGRIND=1".
+Use the VERBOSE environment variable to diagnose building problems,
+and the BUILDER_EXCLUDE_SETCAP and VALGRIND environment variables to find memory
+leaks.
+For example: "make VERBOSE=1", or "make BUILDER_EXCLUDE_SETCAP=1 VALGRIND=1".
  
 Generating Documentation
 ------------------------

--- a/init.mk
+++ b/init.mk
@@ -53,7 +53,7 @@ ifndef SUBMODULE_LOXIGEN_ARTIFACTS
 endif
 
 ifdef SUBMODULES_LOCAL
-  SUBMODULES_LOCAL_UPDATE := $(shell python $(ROOT)/submodules/init.py --update $(SUBMODULES_LOCAL))
+  SUBMODULES_LOCAL_UPDATE := $(shell python3 $(ROOT)/submodules/init.py --update $(SUBMODULES_LOCAL))
   ifneq ($(lastword $(SUBMODULES_LOCAL_UPDATE)),submodules:ok.)
     $(info Local submodule update failed.)
     $(info Result:)

--- a/submodules/init.py
+++ b/submodules/init.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 ################################################################
 #
 #        Copyright 2013, Big Switch Networks, Inc.
@@ -55,30 +55,30 @@ os.chdir(ops.root)
 # Get the status of all submodules
 submodule_status = {}
 try:
-    for entry in subprocess.check_output(['git', 'submodule', 'status']).split("\n"):
+    for entry in subprocess.check_output(['git', 'submodule', 'status']).decode().split("\n"):
         data = entry.split()
         if len(data) >= 2:
             submodule_status[data[1].replace("submodules/", "")] = data[0]
-except Exception, e:
-    print repr(e)
+except Exception as e:
+    print(repr(e))
     raise
 
 if ops.list:
-    for (module, status) in submodule_status.iteritems():
-        print module
+    for (module, status) in submodule_status.items():
+        print(module)
 
 if ops.update:
-    for (module, status) in submodule_status.iteritems():
+    for (module, status) in submodule_status.items():
         if module in ops.update or "all" in ops.update:
             if status[0] == '-':
                 # This submodule has not yet been updated
-                print "Updating submodule %s" % module
+                print("Updating submodule %s" % module)
                 if subprocess.check_call(['git', 'submodule', 'update', '--init', 'submodules/%s' % module]) != 0:
-                    print "git error updating module '%s'." % (module, switchlight_root, module)
+                    print("git error updating module '%s'." % (module, switchlight_root, module))
                     sys.exit(1)
             else:
-                print "Submodule %s is already checked out." % module
-    print "submodules:ok."
+                print("Submodule %s is already checked out." % module)
+    print("submodules:ok.")
 
 
 


### PR DESCRIPTION
Reviewer: @archerhungbsn 
Update README.md with valgrind build info.
The majority of the changes to submodules/init.py were obtained by running 2to3 on that python script; only the additional call to decode() (to convert from byte array to string) and the shebang changes were hand-crafted.
