### PR TITLE
utest memory leak cleanup

### DIFF
--- a/modules/OFStateManager/module/src/group_handlers.c
+++ b/modules/OFStateManager/module/src/group_handlers.c
@@ -465,6 +465,12 @@ ind_core_group_init(void)
     AIM_TRUE_OR_DIE(ind_core_group_hashtable != NULL);
 }
 
+void
+ind_core_group_finish(void)
+{
+    bighash_table_destroy(ind_core_group_hashtable, NULL);
+}
+
 /*
  * Group table management
  */

--- a/modules/OFStateManager/module/src/histogram_handlers.c
+++ b/modules/OFStateManager/module/src/histogram_handlers.c
@@ -55,6 +55,14 @@ ind_core_histogram_handlers_init(void)
     }
 }
 
+void
+ind_core_histogram_handlers_finish(void)
+{
+    histogram_destroy(test_histogram);
+    indigo_core_generic_stats_unregister("histograms");
+    indigo_core_generic_stats_unregister("histogram");
+}
+
 static void
 handle_histogram_request(
     indigo_cxn_id_t cxn_id,

--- a/modules/OFStateManager/module/src/ofstatemanager.c
+++ b/modules/OFStateManager/module/src/ofstatemanager.c
@@ -723,15 +723,23 @@ ind_core_finish(void)
 
     ind_core_bsn_gentable_handler_finish();
 
+    ind_core_histogram_handlers_finish();
+
     /* Indicate core is shutting down */
     if (ind_core_module_enabled) {
         AIM_LOG_VERBOSE("Finish is calling disable");
         ind_core_enable_set(0);
     }
 
-    ft_destroy(ind_core_ft);
+    ind_core_port_finish();
 
     ind_core_test_gentable_finish();
+
+    ind_core_group_finish();
+
+    ft_destroy(ind_core_ft);
+
+    ind_cfg_unregister(&ind_core_cfg_ops);
 
     ind_core_init_done = 0;
 

--- a/modules/OFStateManager/module/src/ofstatemanager_decs.h
+++ b/modules/OFStateManager/module/src/ofstatemanager_decs.h
@@ -45,7 +45,9 @@ extern void ind_core_flow_entry_delete(ft_entry_t *entry,
                                        indigo_cxn_id_t cxn_id);
 
 void ind_core_group_init(void);
+void ind_core_group_finish(void);
 
 void ind_core_histogram_handlers_init(void);
+void ind_core_histogram_handlers_finish(void);
 
 #endif /* OFSTATEMANAGER_DECS_H */

--- a/modules/OFStateManager/module/src/port.c
+++ b/modules/OFStateManager/module/src/port.c
@@ -89,3 +89,10 @@ ind_core_port_init(void)
     ind_core_port_allocator = slot_allocator_create(OFSTATEMANAGER_CONFIG_MAX_PORTS);
     ind_core_queue_allocator = slot_allocator_create(OFSTATEMANAGER_CONFIG_MAX_QUEUES);
 }
+
+void
+ind_core_port_finish(void)
+{
+    slot_allocator_destroy(ind_core_queue_allocator);
+    slot_allocator_destroy(ind_core_port_allocator);
+}

--- a/modules/OFStateManager/module/src/port.h
+++ b/modules/OFStateManager/module/src/port.h
@@ -45,5 +45,6 @@ extern struct ind_core_queue ind_core_queues[OFSTATEMANAGER_CONFIG_MAX_QUEUES];
 extern int ind_core_ports_registered;
 
 void ind_core_port_init(void);
+void ind_core_port_finish(void);
 
 #endif

--- a/modules/OFStateManager/utest/main.c
+++ b/modules/OFStateManager/utest/main.c
@@ -1563,8 +1563,13 @@ aim_main(int argc, char* argv[])
     RUN_TEST(modify);
     RUN_TEST(modify_strict);
 
+    indigo_core_table_unregister(0);
+
     TRY(ind_core_enable_set(0));
     TRY(ind_core_finish());
+
+    ind_soc_enable_set(0);
+    ind_soc_finish();
 
     return global_error;
 }

--- a/modules/SocketManager/utest/main.c
+++ b/modules/SocketManager/utest/main.c
@@ -689,6 +689,8 @@ aim_main(int argc, char* argv[])
     test_task();
     test_priority();
 
+    ind_soc_finish();
+
     return 0;
 }
 


### PR DESCRIPTION
Reviewer: @archerhungbsn 
Add missing *_finish() functions
Invoke unregister/finish functions from SocketManager and OFStateManager utests