### PR TITLE
Free memory after use in minimatch utest

### DIFF
--- a/modules/minimatch/utest/main.c
+++ b/modules/minimatch/utest/main.c
@@ -207,6 +207,9 @@ test_random(void)
                 collisions++;
             }
         }
+
+        minimatch_cleanup(&minimatch_a);
+        minimatch_cleanup(&minimatch_b);
     }
 
     AIM_ASSERT(collisions < num_iters/10000, "too many hash collisions (%d)", collisions);


### PR DESCRIPTION
Reviewer: @archerhungbsn 

```
==2198093== HEAP SUMMARY:
==2198093==     in use at exit: 0 bytes in 0 blocks
==2198093==   total heap usage: 2,000,003 allocs, 2,000,003 frees, 51,987,816 bytes allocated
==2198093== 
==2198093== All heap blocks were freed -- no leaks are possible
==2198093== 
==2198093== For lists of detected and suppressed errors, rerun with: -s
==2198093== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
** Finished Unit Test: ./build/gcc-local/bin/utest_minimatch
```
