### PR TITLE
swl-6634 passive pollhup handling

### DIFF
--- a/modules/OFConnectionManager2/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.c
@@ -1628,6 +1628,7 @@ cxn_socket_ready(
         } else if (error_seen & POLLHUP) {
             LOG_TRACE(cxn, "socket disconnected");
             cxn->controller->hup_count++;
+            cxn->controller->fail_count++;
         } else {
             int socket_error = 0;
             socklen_t len = sizeof(socket_error);

--- a/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
+++ b/modules/OFConnectionManager2/module/src/ofconnectionmanager.c
@@ -702,7 +702,7 @@ listen_socket_ready(int socket_id, void *cookie, int read_ready,
                 AIM_LOG_INFO("Listen cxn %s: socket has a bad file descriptor", listen_cxn->desc);
                 listen_cxn->controller->badfd_count++;
             } else if (error_seen & POLLHUP) {
-                AIM_LOG_INFO("Listen cxn %s: socket disconnected", listen_cxn->desc);
+                AIM_LOG_TRACE("Listen cxn %s: socket disconnected", listen_cxn->desc);
                 listen_cxn->controller->hup_count++;
             }
             /* listen cxn doesn't go through connection state.


### PR DESCRIPTION
Reviewer: @kenchiang 
Bump the fail_count when pollhup so that the retry timer will be extended after each retry. The log level message was fixed in another branch and will bring that fix to the previous branch.