### PR TITLE
add port queue stats handler API

### DIFF
--- a/modules/OFStateManager/module/src/handlers.c
+++ b/modules/OFStateManager/module/src/handlers.c
@@ -313,17 +313,7 @@ ind_core_queue_stats_request_handler(of_object_t *_obj, indigo_cxn_id_t cxn_id)
         of_queue_stats_entry_delete(queue_stats);
         indigo_cxn_send_controller_message(cxn_id, reply);
     } else if (indigo_port_queue_stats_get_handler) {
-        rv = indigo_port_queue_stats_get_handler(obj, cxn_id);
-        if (rv == INDIGO_ERROR_NONE) {
-            of_port_no_t port_no;
-            uint32_t queue_id;
-            of_queue_stats_request_port_no_get(obj, &port_no);
-            of_queue_stats_request_queue_id_get(obj, &queue_id);
-            AIM_LOG_ERROR("Failed to get stats for queue %u on port %u: %s",
-                          queue_id, port_no, indigo_strerror(rv));
-            /* @todo sending type 0, code 0 error message */
-            indigo_cxn_send_error_reply(cxn_id, obj, 0, 0);
-        }
+        (void) indigo_port_queue_stats_get_handler(obj, cxn_id);
     } else if (indigo_port_queue_stats_get) {
         rv = indigo_port_queue_stats_get(obj, &reply);
         if (rv == INDIGO_ERROR_NONE) {

--- a/modules/OFStateManager/module/src/handlers.c
+++ b/modules/OFStateManager/module/src/handlers.c
@@ -313,7 +313,7 @@ ind_core_queue_stats_request_handler(of_object_t *_obj, indigo_cxn_id_t cxn_id)
         of_queue_stats_entry_delete(queue_stats);
         indigo_cxn_send_controller_message(cxn_id, reply);
     } else if (indigo_port_queue_stats_get_handler) {
-        (void) indigo_port_queue_stats_get_handler(obj, cxn_id);
+        indigo_port_queue_stats_get_handler(obj, cxn_id);
     } else if (indigo_port_queue_stats_get) {
         rv = indigo_port_queue_stats_get(obj, &reply);
         if (rv == INDIGO_ERROR_NONE) {

--- a/modules/OFStateManager/module/src/handlers.c
+++ b/modules/OFStateManager/module/src/handlers.c
@@ -312,6 +312,18 @@ ind_core_queue_stats_request_handler(of_object_t *_obj, indigo_cxn_id_t cxn_id)
 
         of_queue_stats_entry_delete(queue_stats);
         indigo_cxn_send_controller_message(cxn_id, reply);
+    } else if (indigo_port_queue_stats_get_handler) {
+        rv = indigo_port_queue_stats_get_handler(obj, cxn_id);
+        if (rv == INDIGO_ERROR_NONE) {
+            of_port_no_t port_no;
+            uint32_t queue_id;
+            of_queue_stats_request_port_no_get(obj, &port_no);
+            of_queue_stats_request_queue_id_get(obj, &queue_id);
+            AIM_LOG_ERROR("Failed to get stats for queue %u on port %u: %s",
+                          queue_id, port_no, indigo_strerror(rv));
+            /* @todo sending type 0, code 0 error message */
+            indigo_cxn_send_error_reply(cxn_id, obj, 0, 0);
+        }
     } else if (indigo_port_queue_stats_get) {
         rv = indigo_port_queue_stats_get(obj, &reply);
         if (rv == INDIGO_ERROR_NONE) {
@@ -326,7 +338,7 @@ ind_core_queue_stats_request_handler(of_object_t *_obj, indigo_cxn_id_t cxn_id)
             of_queue_stats_request_port_no_get(obj, &port_no);
             of_queue_stats_request_queue_id_get(obj, &queue_id);
             AIM_LOG_ERROR("Failed to get stats for queue %u on port %u: %s",
-                        queue_id, port_no, indigo_strerror(rv));
+                          queue_id, port_no, indigo_strerror(rv));
             /* @todo sending type 0, code 0 error message */
             indigo_cxn_send_error_reply(cxn_id, obj, 0, 0);
         }

--- a/modules/indigo/module/inc/indigo/port_manager.h
+++ b/modules/indigo/module/inc/indigo/port_manager.h
@@ -226,10 +226,11 @@ extern indigo_error_t indigo_port_queue_config_get(
 
 
 /**
- * @brief Process an OF queue stats request handler
+ * @brief Prototype of an OF queue stats request handler; if defined, this
+ *        handler will be called when a port queue stats request is received
  * @param queue_stats_request The LOXI request message
  * @param cxn_id Connection ID on which the message arrived
- * @return Return code from operation
+ * @return Return code from handler() and is ignored by indigo
  *
  * Ownership of the queue_stats_request LOXI object is maintained by the
  * caller (OF state manager) and the handler will send the reply. This

--- a/modules/indigo/module/inc/indigo/port_manager.h
+++ b/modules/indigo/module/inc/indigo/port_manager.h
@@ -226,6 +226,22 @@ extern indigo_error_t indigo_port_queue_config_get(
 
 
 /**
+ * @brief Process an OF queue stats request handler
+ * @param queue_stats_request The LOXI request message
+ * @param cxn_id Connection ID on which the message arrived
+ * @return Return code from operation
+ *
+ * Ownership of the queue_stats_request LOXI object is maintained by the
+ * caller (OF state manager) and the handler will send the reply. This
+ * API will take the ownership of allocating reply buffer and sending
+ * reply messages.
+ */
+
+extern indigo_error_t indigo_port_queue_stats_get_handler(
+    of_queue_stats_request_t *queue_stats_request,
+    indigo_cxn_id_t cxn_id) AIM_COMPILER_ATTR_WEAK;
+
+/**
  * @brief Process an OF queue stats request
  * @param queue_stats_request The LOXI request message
  * @param [out] queue_stats_reply The LOXI reply message

--- a/modules/indigo/module/inc/indigo/port_manager.h
+++ b/modules/indigo/module/inc/indigo/port_manager.h
@@ -230,7 +230,6 @@ extern indigo_error_t indigo_port_queue_config_get(
  *        handler will be called when a port queue stats request is received
  * @param queue_stats_request The LOXI request message
  * @param cxn_id Connection ID on which the message arrived
- * @return Return code from handler() and is ignored by indigo
  *
  * Ownership of the queue_stats_request LOXI object is maintained by the
  * caller (OF state manager) and the handler will send the reply. This
@@ -238,7 +237,7 @@ extern indigo_error_t indigo_port_queue_config_get(
  * reply messages.
  */
 
-extern indigo_error_t indigo_port_queue_stats_get_handler(
+extern void indigo_port_queue_stats_get_handler(
     of_queue_stats_request_t *queue_stats_request,
     indigo_cxn_id_t cxn_id) AIM_COMPILER_ATTR_WEAK;
 


### PR DESCRIPTION
Reviewer: @kenchiang @nick-bsn 
Due to port queue stats buffer overrun in wildcard case, the new API will handle the multiple reply messages.