### PR TITLE
Fixed Segmentation fault.

### DIFF
--- a/modules/OFConnectionManager2/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.c
@@ -1156,14 +1156,11 @@ send_parse_error_message(connection_t *cxn, uint8_t *buf, int len)
     /* truncate payload to fit in wire buffer */
     payload.bytes = (len < maxlen)? len: maxlen;
    
-    if (!(OFVERSION_IS_SET(cxn)))
-    {
+    if (!(OFVERSION_IS_SET(cxn))) {
         indigo_cxn_config_params_t *config_params = get_connection_config(cxn);
-
         error_msg = of_bad_request_error_msg_new(config_params->version);
     }
-    else
-    {
+    else {
         error_msg = of_bad_request_error_msg_new(cxn->status.negotiated_version);
     }
     

--- a/modules/OFConnectionManager2/module/src/cxn_instance.c
+++ b/modules/OFConnectionManager2/module/src/cxn_instance.c
@@ -1121,6 +1121,7 @@ read_message(connection_t *cxn)
     return INDIGO_ERROR_PENDING;
 }
 
+#define OFVERSION_IS_SET(cxn) ((cxn)->status.negotiated_version > 0)
 /**
  * Send an error for a message that we couldn't parse
  *
@@ -1154,8 +1155,18 @@ send_parse_error_message(connection_t *cxn, uint8_t *buf, int len)
     payload.data = buf;
     /* truncate payload to fit in wire buffer */
     payload.bytes = (len < maxlen)? len: maxlen;
+   
+    if (!(OFVERSION_IS_SET(cxn)))
+    {
+        indigo_cxn_config_params_t *config_params = get_connection_config(cxn);
 
-    error_msg = of_bad_request_error_msg_new(cxn->status.negotiated_version);
+        error_msg = of_bad_request_error_msg_new(config_params->version);
+    }
+    else
+    {
+        error_msg = of_bad_request_error_msg_new(cxn->status.negotiated_version);
+    }
+    
     if (error_msg == NULL) {
         AIM_DIE("Could not allocate error message");
     }
@@ -1171,7 +1182,6 @@ send_parse_error_message(connection_t *cxn, uint8_t *buf, int len)
 }
 
 
-#define OFVERSION_IS_SET(cxn) ((cxn)->status.negotiated_version > 0)
 
 /**
  * Process a message from the read buffer


### PR DESCRIPTION
RCA
------
Segmentation fault occurs when the version is 0.
This is a negative test case, found during unit testing.

Fix
------
Instead of using the incoming packet version 0, the configured version is used for error reply construction.